### PR TITLE
feat: add close methods to container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Tests in `tests/` use fixtures from `conftest.py`:
 
 Main exports from `diwire`:
 - `Container` - DI container
-- `Lifetime` - TRANSIENT, SINGLETON, SCOPED_SINGLETON
+- `Lifetime` - TRANSIENT, SINGLETON, SCOPED
 - `Injected` - Mark function parameters for injection
 - `Component` - Named component registration
 - `container_context` - Global context for lazy resolution

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ def session_factory() -> Generator[Session, None, None]:
 container = Container()
 container.register(Session, factory=session_factory, lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
 
-with container.start_scope("request") as scope:
+with container.enter_scope("request") as scope:
     session = scope.resolve(Session)
     assert session.closed is False
 ```
@@ -269,7 +269,7 @@ async def main() -> None:
         scope="request",
     )
 
-    async with container.start_scope("request") as scope:
+    async with container.enter_scope("request") as scope:
         await scope.aresolve(AsyncClient)
 
 
@@ -307,7 +307,7 @@ print(greet())
 
 ## API at a glance
 
-- `Container`: `register`, `resolve`, `aresolve`, `start_scope`, `compile`
+- `Container`: `register`, `resolve`, `aresolve`, `enter_scope`, `compile`
 - `Lifetime`: `TRANSIENT`, `SINGLETON`, `SCOPED_SINGLETON`
 - `Injected`: `Annotated[T, Injected()]` parameter marker
 - `container_context`: context-local global container

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ def session_factory() -> Generator[Session, None, None]:
 
 
 container = Container()
-container.register(Session, factory=session_factory, lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+container.register(Session, factory=session_factory, lifetime=Lifetime.SCOPED, scope="request")
 
 with container.enter_scope("request") as scope:
     session = scope.resolve(Session)
@@ -265,7 +265,7 @@ async def main() -> None:
     container.register(
         AsyncClient,
         factory=client_factory,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
     )
 
@@ -308,7 +308,7 @@ print(greet())
 ## API at a glance
 
 - `Container`: `register`, `resolve`, `aresolve`, `enter_scope`, `compile`
-- `Lifetime`: `TRANSIENT`, `SINGLETON`, `SCOPED_SINGLETON`
+- `Lifetime`: `TRANSIENT`, `SINGLETON`, `SCOPED`
 - `Injected`: `Annotated[T, Injected()]` parameter marker
 - `container_context`: context-local global container
 - `Component` and `ServiceKey`: named registrations

--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ container.register(Session, factory=session_factory, lifetime=Lifetime.SCOPED, s
 with container.enter_scope("request") as scope:
     session = scope.resolve(Session)
     assert session.closed is False
+
+# Or close scopes by name (closes child scopes automatically)
+container.enter_scope("app")
+container.enter_scope("request")
+container.close_scope("app")  # Closes both "request" and "app" in LIFO order
 ```
 
 ## Named components
@@ -307,7 +312,7 @@ print(greet())
 
 ## API at a glance
 
-- `Container`: `register`, `resolve`, `aresolve`, `enter_scope`, `compile`
+- `Container`: `register`, `resolve`, `aresolve`, `enter_scope`, `close_scope`, `aclose_scope`, `compile`
 - `Lifetime`: `TRANSIENT`, `SINGLETON`, `SCOPED`
 - `Injected`: `Annotated[T, Injected()]` parameter marker
 - `container_context`: context-local global container

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,7 +28,7 @@ uv run python examples/ex08_fastapi/ex01_basic.py
 | File                                                                   | Description                                           |
 |------------------------------------------------------------------------|-------------------------------------------------------|
 | [ex01_scope_basics.py](ex02_scopes/ex01_scope_basics.py)               | Using `enter_scope()` context manager                 |
-| [ex02_scoped_singleton.py](ex02_scopes/ex02_scoped_singleton.py)       | SCOPED_SINGLETON lifetime for request-local instances |
+| [ex02_scoped_singleton.py](ex02_scopes/ex02_scoped_singleton.py)       | SCOPED lifetime for request-local instances |
 | [ex03_nested_scopes.py](ex02_scopes/ex03_nested_scopes.py)             | Nested scope hierarchies                              |
 | [ex04_generator_factories.py](ex02_scopes/ex04_generator_factories.py) | Generator factories with cleanup on scope exit        |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ uv run python examples/ex08_fastapi/ex01_basic.py
 
 | File                                                                   | Description                                           |
 |------------------------------------------------------------------------|-------------------------------------------------------|
-| [ex01_scope_basics.py](ex02_scopes/ex01_scope_basics.py)               | Using `start_scope()` context manager                 |
+| [ex01_scope_basics.py](ex02_scopes/ex01_scope_basics.py)               | Using `enter_scope()` context manager                 |
 | [ex02_scoped_singleton.py](ex02_scopes/ex02_scoped_singleton.py)       | SCOPED_SINGLETON lifetime for request-local instances |
 | [ex03_nested_scopes.py](ex02_scopes/ex03_nested_scopes.py)             | Nested scope hierarchies                              |
 | [ex04_generator_factories.py](ex02_scopes/ex04_generator_factories.py) | Generator factories with cleanup on scope exit        |

--- a/examples/ex01_basics/ex04_decorator_registration.py
+++ b/examples/ex01_basics/ex04_decorator_registration.py
@@ -212,7 +212,7 @@ def main() -> None:
 
     # Resolve scoped singleton within a scope
     print("=== Scoped Singleton Demo ===")
-    with container.start_scope("request") as scope:
+    with container.enter_scope("request") as scope:
         ctx1 = scope.resolve(RequestContext)
         ctx2 = scope.resolve(RequestContext)
         print(f"Same request context: {ctx1 is ctx2}")
@@ -254,7 +254,7 @@ async def async_main() -> None:
 
     # Resolve async generator factory within scope
     print("\n=== Async Generator Factory with Cleanup ===")
-    async with container.start_scope("request") as scope:
+    async with container.enter_scope("request") as scope:
         conn = await scope.aresolve(DatabaseConnection)
         print(f"Connection active: {conn.connected}")
     print(f"Connection after scope exit: {conn.connected}")

--- a/examples/ex01_basics/ex04_decorator_registration.py
+++ b/examples/ex01_basics/ex04_decorator_registration.py
@@ -5,7 +5,7 @@ Demonstrates using @container.register as a decorator for:
 2. Factory function registration with type inference
 3. Interface/Protocol registration via @container.register(Interface)
 4. Factory functions with auto-injected dependencies
-5. Scoped singleton decorator usage
+5. Scoped decorator usage
 6. Async factory function registration
 7. Static method factories
 8. Async generator factories with cleanup
@@ -102,8 +102,8 @@ def create_user_repository(db: IDatabase, logger: Logger) -> UserRepository:
     return UserRepository(db=db, logger=logger)
 
 
-# Pattern 7: Scoped singleton with decorator
-@container.register(lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+# Pattern 7: Scoped with decorator
+@container.register(lifetime=Lifetime.SCOPED, scope="request")
 class RequestContext:
     """A request-scoped context object."""
 
@@ -172,7 +172,7 @@ class DatabaseConnection:
 
 
 # Note: Factory defined outside class to avoid forward reference issues
-@container.register(lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+@container.register(lifetime=Lifetime.SCOPED, scope="request")
 async def create_db_connection() -> AsyncGenerator[DatabaseConnection, None]:
     """Async generator factory with automatic cleanup."""
     conn = DatabaseConnection()
@@ -210,8 +210,8 @@ def main() -> None:
     print(f"UserRepository has db: {repo.db is not None}")
     print(f"UserRepository has logger: {repo.logger is not None}\n")
 
-    # Resolve scoped singleton within a scope
-    print("=== Scoped Singleton Demo ===")
+    # Resolve scoped within a scope
+    print("=== Scoped Demo ===")
     with container.enter_scope("request") as scope:
         ctx1 = scope.resolve(RequestContext)
         ctx2 = scope.resolve(RequestContext)

--- a/examples/ex02_scopes/ex01_scope_basics.py
+++ b/examples/ex02_scopes/ex01_scope_basics.py
@@ -1,6 +1,6 @@
 """Scope Basics in DIWire.
 
-Demonstrates how to use scopes with start_scope() context manager.
+Demonstrates how to use scopes with enter_scope() context manager.
 Scopes allow grouping related service resolutions together.
 """
 
@@ -29,10 +29,10 @@ def main() -> None:
     container = Container()
     container.register(RequestContext)
 
-    # Using start_scope() with an Enum value
+    # Using enter_scope() with an Enum value
     print("Scope usage with context manager:\n")
 
-    with container.start_scope(Scope.REQUEST) as scope:
+    with container.enter_scope(Scope.REQUEST) as scope:
         # Resolve services within the scope
         ctx1 = scope.resolve(RequestContext)
         ctx2 = scope.resolve(RequestContext)
@@ -45,11 +45,11 @@ def main() -> None:
     # Each scope is independent
     print("\nMultiple independent scopes:")
 
-    with container.start_scope(Scope.REQUEST) as scope1:
+    with container.enter_scope(Scope.REQUEST) as scope1:
         ctx_a = scope1.resolve(RequestContext)
         print(f"  Scope 1 context: {ctx_a}")
 
-    with container.start_scope(Scope.REQUEST) as scope2:
+    with container.enter_scope(Scope.REQUEST) as scope2:
         ctx_b = scope2.resolve(RequestContext)
         print(f"  Scope 2 context: {ctx_b}")
 

--- a/examples/ex02_scopes/ex02_scoped_singleton.py
+++ b/examples/ex02_scopes/ex02_scoped_singleton.py
@@ -1,6 +1,6 @@
-"""Scoped Singleton Lifetime in DIWire.
+"""Scoped Lifetime in DIWire.
 
-Demonstrates SCOPED_SINGLETON:
+Demonstrates SCOPED:
 - Same instance within a scope
 - Different instance across scopes
 """
@@ -36,20 +36,21 @@ class Repository:
 def main() -> None:
     container = Container()
 
-    # Register Session as SCOPED_SINGLETON for REQUEST scope
+    # Register Session as SCOPED for REQUEST scope
     container.register(
         Session,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.REQUEST,
     )
     container.register(Repository)
 
-    print("SCOPED_SINGLETON behavior:\n")
+    print("SCOPED behavior:\n")
 
     # Within the same scope, Session is shared
     with container.enter_scope(Scope.REQUEST) as scope:
         session1 = scope.resolve(Session)
-        session2 = scope.resolve(Session)
+        with scope.enter_scope("222") as scope2:
+            session2 = scope2.resolve(Session)
         repo = scope.resolve(Repository)
 
         print("Request Scope 1:")

--- a/examples/ex02_scopes/ex02_scoped_singleton.py
+++ b/examples/ex02_scopes/ex02_scoped_singleton.py
@@ -49,8 +49,7 @@ def main() -> None:
     # Within the same scope, Session is shared
     with container.enter_scope(Scope.REQUEST) as scope:
         session1 = scope.resolve(Session)
-        with scope.enter_scope("222") as scope2:
-            session2 = scope2.resolve(Session)
+        session2 = scope.resolve(Session)
         repo = scope.resolve(Repository)
 
         print("Request Scope 1:")

--- a/examples/ex02_scopes/ex02_scoped_singleton.py
+++ b/examples/ex02_scopes/ex02_scoped_singleton.py
@@ -47,7 +47,7 @@ def main() -> None:
     print("SCOPED_SINGLETON behavior:\n")
 
     # Within the same scope, Session is shared
-    with container.start_scope(Scope.REQUEST) as scope:
+    with container.enter_scope(Scope.REQUEST) as scope:
         session1 = scope.resolve(Session)
         session2 = scope.resolve(Session)
         repo = scope.resolve(Repository)
@@ -59,7 +59,7 @@ def main() -> None:
         print(f"  All same instance: {session1 is session2 is repo.session}")
 
     # Different scope = different Session instance
-    with container.start_scope(Scope.REQUEST) as scope:
+    with container.enter_scope(Scope.REQUEST) as scope:
         session3 = scope.resolve(Session)
         repo2 = scope.resolve(Repository)
 

--- a/examples/ex02_scopes/ex03_nested_scopes.py
+++ b/examples/ex02_scopes/ex03_nested_scopes.py
@@ -46,12 +46,12 @@ def main() -> None:
 
     print("Nested scopes demonstration:\n")
 
-    with container.start_scope(Scope.REQUEST) as request_scope:
+    with container.enter_scope(Scope.REQUEST) as request_scope:
         request_ctx = request_scope.resolve(RequestContext)
         print(f"Request scope - RequestContext id: {request_ctx.request_id}")
 
         # Create nested handler scopes
-        with request_scope.start_scope(Scope.HANDLER) as handler_scope1:
+        with request_scope.enter_scope(Scope.HANDLER) as handler_scope1:
             handler_ctx1 = handler_scope1.resolve(HandlerContext)
             # Parent's RequestContext is accessible from child
             inherited_request_ctx = handler_scope1.resolve(RequestContext)
@@ -61,7 +61,7 @@ def main() -> None:
             print(f"    RequestContext id: {inherited_request_ctx.request_id}")
             print(f"    Same request context: {inherited_request_ctx is request_ctx}")
 
-        with request_scope.start_scope(Scope.HANDLER) as handler_scope2:
+        with request_scope.enter_scope(Scope.HANDLER) as handler_scope2:
             handler_ctx2 = handler_scope2.resolve(HandlerContext)
             inherited_request_ctx2 = handler_scope2.resolve(RequestContext)
 

--- a/examples/ex02_scopes/ex03_nested_scopes.py
+++ b/examples/ex02_scopes/ex03_nested_scopes.py
@@ -35,12 +35,12 @@ def main() -> None:
 
     container.register(
         RequestContext,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.REQUEST,
     )
     container.register(
         HandlerContext,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.HANDLER,
     )
 

--- a/examples/ex02_scopes/ex04_generator_factories.py
+++ b/examples/ex02_scopes/ex04_generator_factories.py
@@ -48,7 +48,7 @@ def main() -> None:
     container.register(
         Session,
         factory=session_factory,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.REQUEST,
     )
 

--- a/examples/ex02_scopes/ex04_generator_factories.py
+++ b/examples/ex02_scopes/ex04_generator_factories.py
@@ -53,7 +53,7 @@ def main() -> None:
     )
 
     print("Generator factory scope behavior:\n")
-    with container.start_scope(Scope.REQUEST):
+    with container.enter_scope(Scope.REQUEST):
         session1 = container.resolve(Session)
         session2 = container.resolve(Session)
         print(f"session1: {session1}")

--- a/examples/ex03_function_injection/ex03_scoped_injected.py
+++ b/examples/ex03_function_injection/ex03_scoped_injected.py
@@ -65,10 +65,10 @@ def handle_request(
 def main() -> None:
     container = Container()
 
-    # RequestSession is SCOPED_SINGLETON - shared within a scope
+    # RequestSession is SCOPED - shared within a scope
     container.register(
         RequestSession,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.REQUEST,
     )
     container.register(UserService)

--- a/examples/ex05_patterns/ex01_request_handler.py
+++ b/examples/ex05_patterns/ex01_request_handler.py
@@ -86,7 +86,7 @@ def main() -> None:
     # RequestContext is shared within each request
     container.register(
         RequestContext,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.REQUEST,
     )
     # Services are transient but receive the scoped RequestContext

--- a/examples/ex05_patterns/ex02_repository.py
+++ b/examples/ex05_patterns/ex02_repository.py
@@ -84,10 +84,10 @@ def create_user_with_order(
 def main() -> None:
     container = Container()
 
-    # Session is SCOPED_SINGLETON - same session for entire unit of work
+    # Session is SCOPED - same session for entire unit of work
     container.register(
         Session,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.UNIT_OF_WORK,
     )
     # Repositories are transient but share the scoped session

--- a/examples/ex05_patterns/ex02_repository.py
+++ b/examples/ex05_patterns/ex02_repository.py
@@ -111,7 +111,7 @@ def main() -> None:
 
     # Manual scope management example
     print("Manual scope management:")
-    with container.start_scope(Scope.UNIT_OF_WORK) as scope:
+    with container.enter_scope(Scope.UNIT_OF_WORK) as scope:
         user_repo = scope.resolve(UserRepository)
         order_repo = scope.resolve(OrderRepository)
         session = scope.resolve(Session)

--- a/examples/ex06_async/ex02_async_generator_cleanup.py
+++ b/examples/ex06_async/ex02_async_generator_cleanup.py
@@ -58,7 +58,7 @@ async def main() -> None:
     print("Starting request scope...")
 
     # Use async context manager for proper cleanup
-    async with container.start_scope("request"):
+    async with container.enter_scope("request"):
         session = await container.aresolve(DatabaseSession)
         print(f"  Got session: {session.session_id}")
 

--- a/examples/ex06_async/ex02_async_generator_cleanup.py
+++ b/examples/ex06_async/ex02_async_generator_cleanup.py
@@ -51,7 +51,7 @@ async def main() -> None:
     container.register(
         DatabaseSession,
         factory=create_session,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
     )
 

--- a/examples/ex06_async/ex04_async_scoped_injection.py
+++ b/examples/ex06_async/ex04_async_scoped_injection.py
@@ -75,13 +75,13 @@ async def main() -> None:
     # Register scoped dependencies
     container.register(
         RequestContext,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
     )
     container.register(
         DatabaseTransaction,
         factory=create_transaction,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
     )
 

--- a/examples/ex06_async/ex06_error_handling.py
+++ b/examples/ex06_async/ex06_error_handling.py
@@ -71,7 +71,7 @@ async def demonstrate_async_gen_without_scope() -> None:
         print(f"Caught: {type(e).__name__}")
         print(f"Message: {e}")
         print(
-            "\nSolution: Register with scope='request' and use 'async with container.start_scope()'",
+            "\nSolution: Register with scope='request' and use 'async with container.enter_scope()'",
         )
 
 
@@ -97,7 +97,7 @@ async def demonstrate_proper_usage() -> None:
     )
 
     print("\n2. Resolving async generator with scope:")
-    async with container.start_scope("request"):
+    async with container.enter_scope("request"):
         session = await container.aresolve("Session")
         print(f"   Got: {session}")
     print("   (Cleanup runs automatically on scope exit)")

--- a/examples/ex06_async/ex06_error_handling.py
+++ b/examples/ex06_async/ex06_error_handling.py
@@ -92,7 +92,7 @@ async def demonstrate_proper_usage() -> None:
     container.register(
         "Session",
         factory=session_factory,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
     )
 

--- a/examples/ex06_async/ex07_fastapi_style.py
+++ b/examples/ex06_async/ex07_fastapi_style.py
@@ -198,7 +198,7 @@ def create_container() -> Container:
     container.register(
         DatabaseSession,
         factory=create_db_session,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
     )
 

--- a/examples/ex06_async/ex07_fastapi_style.py
+++ b/examples/ex06_async/ex07_fastapi_style.py
@@ -213,7 +213,7 @@ def create_container() -> Container:
 async def handle_request(container: Container, handler, **kwargs) -> dict:
     """Simulate handling an HTTP request."""
     # Each request gets its own scope
-    async with container.start_scope("request"):
+    async with container.enter_scope("request"):
         # Resolve the handler (gets AsyncScopedInjected due to scoped deps)
         injected_handler = await container.aresolve(handler)
         return await injected_handler(**kwargs)

--- a/examples/ex07_errors/ex03_scope_mismatch.py
+++ b/examples/ex07_errors/ex03_scope_mismatch.py
@@ -22,10 +22,10 @@ class RequestSession:
 def main() -> None:
     container = Container()
 
-    # Register session as SCOPED_SINGLETON for REQUEST scope
+    # Register session as SCOPED for REQUEST scope
     container.register(
         RequestSession,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope=Scope.REQUEST,
     )
 

--- a/examples/ex07_errors/ex03_scope_mismatch.py
+++ b/examples/ex07_errors/ex03_scope_mismatch.py
@@ -33,7 +33,7 @@ def main() -> None:
     print("Scenario: Using a scope reference after it has exited\n")
 
     scope_ref = None
-    with container.start_scope(Scope.REQUEST) as scope:
+    with container.enter_scope(Scope.REQUEST) as scope:
         # Save reference to scope
         scope_ref = scope
         session = scope.resolve(RequestSession)
@@ -51,7 +51,7 @@ def main() -> None:
 
     # Correct usage - always use scopes within their context manager
     print("\nCorrect usage - resolve within active scope context:")
-    with container.start_scope(Scope.REQUEST) as scope:
+    with container.enter_scope(Scope.REQUEST) as scope:
         session = scope.resolve(RequestSession)
         print(f"  Successfully resolved: {session}")
 

--- a/src/diwire/__init__.py
+++ b/src/diwire/__init__.py
@@ -1,12 +1,15 @@
-from diwire.container import Container
+from diwire.container import Container, ScopedContainer
 from diwire.container_context import container_context
+from diwire.exceptions import DIWireContainerClosedError
 from diwire.service_key import Component
 from diwire.types import Injected, Lifetime
 
 __all__ = [
     "Component",
     "Container",
+    "DIWireContainerClosedError",
     "Injected",
     "Lifetime",
+    "ScopedContainer",
     "container_context",
 ]

--- a/src/diwire/container.py
+++ b/src/diwire/container.py
@@ -488,7 +488,8 @@ class ScopedContainer:
         """Close the scope synchronously."""
         if self._exited:
             return
-        _current_scope.reset(self._token)
+        with contextlib.suppress(ValueError, RuntimeError):
+            _current_scope.reset(self._token)
         self._container.clear_scope(self._scope_id)
         self._container._unregister_active_scope(self)  # noqa: SLF001
         self._exited = True
@@ -497,7 +498,8 @@ class ScopedContainer:
         """Close the scope asynchronously."""
         if self._exited:
             return
-        _current_scope.reset(self._token)
+        with contextlib.suppress(ValueError, RuntimeError):
+            _current_scope.reset(self._token)
         await self._container.aclear_scope(self._scope_id)
         self._container._unregister_active_scope(self)  # noqa: SLF001
         self._exited = True

--- a/src/diwire/container_context.py
+++ b/src/diwire/container_context.py
@@ -714,5 +714,29 @@ class ContainerContextProxy:
         """
         return await self.get_current().aclose()
 
+    def close_scope(self, scope_name: str) -> None:
+        """Close all active scopes that contain the given scope name.
+
+        This closes the named scope and all its child scopes in LIFO order
+        (children first, then parents).
+
+        Args:
+            scope_name: The name of the scope to close.
+
+        """
+        return self.get_current().close_scope(scope_name)
+
+    async def aclose_scope(self, scope_name: str) -> None:
+        """Asynchronously close all active scopes that contain the given scope name.
+
+        This closes the named scope and all its child scopes in LIFO order
+        (children first, then parents).
+
+        Args:
+            scope_name: The name of the scope to close.
+
+        """
+        return await self.get_current().aclose_scope(scope_name)
+
 
 container_context = ContainerContextProxy()

--- a/src/diwire/container_context.py
+++ b/src/diwire/container_context.py
@@ -681,7 +681,7 @@ class ContainerContextProxy:
         )
         return None
 
-    def start_scope(self, scope_name: str | None = None) -> Any:
+    def enter_scope(self, scope_name: str | None = None) -> Any:
         """Start a new scope on the current container.
 
         Args:
@@ -691,7 +691,7 @@ class ContainerContextProxy:
             A ScopedContainer context manager.
 
         """
-        return self.get_current().start_scope(scope_name)
+        return self.get_current().enter_scope(scope_name)
 
     def compile(self) -> None:
         """Compile the current container for optimized resolution."""

--- a/src/diwire/container_context.py
+++ b/src/diwire/container_context.py
@@ -15,7 +15,7 @@ from diwire.exceptions import DIWireContainerNotSetError
 from diwire.types import Factory, Lifetime
 
 if TYPE_CHECKING:
-    from diwire.container import Container
+    from diwire.container import Container, ScopedContainer
 
 # Import signature builder to exclude Injected parameters from signature
 from diwire.container import _build_signature_without_injected
@@ -681,7 +681,7 @@ class ContainerContextProxy:
         )
         return None
 
-    def enter_scope(self, scope_name: str | None = None) -> Any:
+    def enter_scope(self, scope_name: str | None = None) -> ScopedContainer:
         """Start a new scope on the current container.
 
         Args:

--- a/src/diwire/container_context.py
+++ b/src/diwire/container_context.py
@@ -697,5 +697,22 @@ class ContainerContextProxy:
         """Compile the current container for optimized resolution."""
         return self.get_current().compile()
 
+    def close(self) -> None:
+        """Close the current container.
+
+        Closes all active scopes and marks the container as closed.
+        After calling this method, any attempt to resolve services or start
+        new scopes will raise DIWireContainerClosedError.
+        """
+        return self.get_current().close()
+
+    async def aclose(self) -> None:
+        """Asynchronously close the current container.
+
+        Use this method when scopes contain async generator factories that
+        need proper async cleanup.
+        """
+        return await self.get_current().aclose()
+
 
 container_context = ContainerContextProxy()

--- a/src/diwire/exceptions.py
+++ b/src/diwire/exceptions.py
@@ -274,3 +274,10 @@ class DIWireInvalidGenericTypeArgumentError(DIWireError):
         super().__init__(
             f"Invalid type argument for {service_key}: {typevar_name}={arg!r}. {reason}",
         )
+
+
+class DIWireContainerClosedError(DIWireError):
+    """Operation attempted on a closed container."""
+
+    def __init__(self) -> None:
+        super().__init__("Cannot perform operation on a closed container.")

--- a/src/diwire/exceptions.py
+++ b/src/diwire/exceptions.py
@@ -125,7 +125,7 @@ class DIWireGeneratorFactoryWithoutScopeError(DIWireError):
         self.service_key = service_key
         super().__init__(
             f"Factory for service {service_key} returned a generator, but no active scope exists. "
-            "Resolve the service within a scope (start_scope) to ensure cleanup.",
+            "Resolve the service within a scope (enter_scope) to ensure cleanup.",
         )
 
 
@@ -169,7 +169,7 @@ class DIWireAsyncGeneratorFactoryWithoutScopeError(DIWireError):
         self.service_key = service_key
         super().__init__(
             f"Factory for service {service_key} is an async generator, but no active scope exists. "
-            "Resolve the service within an async scope (async with container.start_scope()) "
+            "Resolve the service within an async scope (async with container.enter_scope()) "
             "to ensure proper cleanup.",
         )
 
@@ -222,7 +222,7 @@ class DIWireAsyncCleanupWithoutEventLoopError(DIWireError):
         scope_desc = f"'{scope_name}'" if scope_name else "anonymous scope"
         super().__init__(
             f"Scope {scope_desc} has async resources that need cleanup, but no event loop is "
-            "running. Use 'async with container.start_scope()' instead of 'with' when resolving "
+            "running. Use 'async with container.enter_scope()' instead of 'with' when resolving "
             "async generators, or ensure an event loop is running when the scope exits.",
         )
 

--- a/src/diwire/exceptions.py
+++ b/src/diwire/exceptions.py
@@ -107,14 +107,14 @@ class DIWireScopeMismatchError(DIWireError):
         )
 
 
-class DIWireScopedSingletonWithoutScopeError(DIWireError):
-    """SCOPED_SINGLETON registered without a scope."""
+class DIWireScopedWithoutScopeError(DIWireError):
+    """SCOPED registered without a scope."""
 
     def __init__(self, service_key: ServiceKey) -> None:
         self.service_key = service_key
         super().__init__(
-            f"Service {service_key} is registered as SCOPED_SINGLETON but no scope was provided. "
-            f"SCOPED_SINGLETON requires a scope parameter.",
+            f"Service {service_key} is registered as SCOPED but no scope was provided. "
+            f"SCOPED requires a scope parameter.",
         )
 
 

--- a/src/diwire/types.py
+++ b/src/diwire/types.py
@@ -12,7 +12,7 @@ class Lifetime(str, Enum):
     SINGLETON = "singleton"
     """A single instance is created and shared for the lifetime of the container."""
 
-    SCOPED_SINGLETON = "scoped_singleton"
+    SCOPED = "scoped"
     """Instance is shared within a scope, different instances across scopes."""
 
 

--- a/tests/examples/test_basics.py
+++ b/tests/examples/test_basics.py
@@ -70,7 +70,7 @@ def test_ex04_decorator_registration(capsys: pytest.CaptureFixture[str]) -> None
         "Cache: {'initialized': 'true'}",
         "Settings: MyApp v1.0.0",
         "UserRepository has db: True",
-        "=== Scoped Singleton Demo ===",
+        "=== Scoped Demo ===",
         "Same request context: True",
         "=== Context Registration Demo ===",
         "[CTX] Hello from context logger!",

--- a/tests/examples/test_scopes_examples.py
+++ b/tests/examples/test_scopes_examples.py
@@ -36,7 +36,7 @@ def test_ex02_scoped_singleton(capsys: pytest.CaptureFixture[str]) -> None:
 
     assert_output_contains(
         captured.out,
-        "SCOPED_SINGLETON behavior:",
+        "SCOPED behavior:",
         "Request Scope 1:",
         "session1:",
         "session2:",

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -242,7 +242,7 @@ class TestAsyncGeneratorFactory:
             Session,
             factory=session_factory,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         async with container.enter_scope("request"):
@@ -271,7 +271,7 @@ class TestAsyncGeneratorFactory:
             ServiceA,
             factory=resource_factory,
             scope="test",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         async with container.enter_scope("test"):
@@ -303,13 +303,13 @@ class TestAsyncGeneratorFactory:
             Session,
             factory=first_factory,
             scope="test",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.register(
             ServiceA,
             factory=second_factory,
             scope="test",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         async with container.enter_scope("test"):
@@ -336,7 +336,7 @@ class TestAsyncGeneratorFactory:
             ServiceA,
             factory=resource_factory,
             scope="test",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         with pytest.raises(ValueError, match="test error"):
@@ -376,7 +376,7 @@ class TestAsyncGeneratorFactory:
             ServiceA,
             factory=empty_factory,
             scope="test",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         with pytest.raises(DIWireAsyncGeneratorFactoryDidNotYieldError) as exc_info:
@@ -407,7 +407,7 @@ class TestAsyncScope:
 
     async def test_async_scoped_singleton_caching(self, container: Container) -> None:
         """Async scoped singletons are cached within the scope."""
-        container.register(Session, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
 
         async with container.enter_scope("request"):
             session1 = await container.aresolve(Session)
@@ -416,7 +416,7 @@ class TestAsyncScope:
 
     async def test_async_nested_scopes(self, container: Container) -> None:
         """Nested async scopes work correctly."""
-        container.register(Session, scope="child", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="child", lifetime=Lifetime.SCOPED)
 
         async with container.enter_scope("parent") as parent:
             async with parent.enter_scope("child"):
@@ -601,7 +601,7 @@ class TestAsyncScopedInjected:
         container: Container,
     ) -> None:
         """AsyncScopedInjected creates a fresh scope per call."""
-        container.register(Session, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
 
         async def handler(session: Annotated[Session, Injected()]) -> Session:
             return session
@@ -619,7 +619,7 @@ class TestAsyncScopedInjected:
         container: Container,
     ) -> None:
         """AsyncScopedInjected shares scoped instances within a single call."""
-        container.register(Session, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
 
         async def handler(
             x: Annotated[ServiceXForScope, Injected()],
@@ -657,7 +657,7 @@ class TestAsyncConcurrency:
 
     async def test_async_task_isolation(self, container: Container) -> None:
         """Each async task has isolated scope context."""
-        container.register(Session, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
         results: dict[str, str] = {}
 
         async def worker(worker_id: str) -> None:
@@ -674,7 +674,7 @@ class TestAsyncConcurrency:
 
     async def test_concurrent_scope_contexts(self, container: Container) -> None:
         """Concurrent async scopes don't interfere with each other."""
-        container.register(Session, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
         scope_ids: dict[str, str] = {}
 
         async def worker(worker_id: str) -> None:
@@ -764,7 +764,7 @@ class TestScopedContainerAsync:
 
     async def test_scoped_container_aresolve(self, container: Container) -> None:
         """ScopedContainer.aresolve() works correctly."""
-        container.register(Session, scope="test", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="test", lifetime=Lifetime.SCOPED)
 
         async with container.enter_scope("test") as scoped:
             session = await scoped.aresolve(Session)
@@ -775,7 +775,7 @@ class TestScopedContainerAsync:
         container: Container,
     ) -> None:
         """ScopedContainer.aresolve() after scope exit raises error."""
-        container.register(Session, scope="test", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="test", lifetime=Lifetime.SCOPED)
 
         async with container.enter_scope("test") as scoped:
             pass
@@ -986,7 +986,7 @@ class TestAsyncMissingCoverage:
             ServiceA,
             factory=empty_generator,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         async with container.enter_scope("request"):
@@ -1063,7 +1063,7 @@ class TestAresolveScopedOverride:
             ServiceA,
             instance=scoped_instance,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         # Inside a scope, aresolve should return the scoped override, NOT the cached singleton

--- a/tests/test_circular_dependencies.py
+++ b/tests/test_circular_dependencies.py
@@ -184,7 +184,7 @@ class TestScopedCircularDependencies:
         )
 
         with pytest.raises(DIWireCircularDependencyError) as exc_info:
-            with container.start_scope("request"):
+            with container.enter_scope("request"):
                 container.resolve(ScopedCircularA)
 
         assert "ScopedCircularA" in str(exc_info.value)
@@ -200,7 +200,7 @@ class TestScopedCircularDependencies:
         container.register(ScopedToSingletonB, lifetime=Lifetime.SINGLETON)
 
         with pytest.raises(DIWireCircularDependencyError) as exc_info:
-            with container.start_scope("request"):
+            with container.enter_scope("request"):
                 container.resolve(ScopedToSingletonA)
 
         assert "ScopedToSingletonA" in str(exc_info.value)
@@ -216,7 +216,7 @@ class TestScopedCircularDependencies:
         container.register(ScopedToTransientB, lifetime=Lifetime.TRANSIENT)
 
         with pytest.raises(DIWireCircularDependencyError) as exc_info:
-            with container.start_scope("request"):
+            with container.enter_scope("request"):
                 container.resolve(ScopedToTransientA)
 
         assert "ScopedToTransientA" in str(exc_info.value)
@@ -238,7 +238,7 @@ class TestScopedCircularDependencies:
         assert _current_scope.get() is None
 
         try:
-            with container.start_scope("request"):
+            with container.enter_scope("request"):
                 container.resolve(ScopedCircularA)
         except DIWireCircularDependencyError:
             pass
@@ -289,7 +289,7 @@ class TestAsyncCircularDependencies:
         )
 
         with pytest.raises(DIWireCircularDependencyError) as exc_info:
-            async with container.start_scope("request"):
+            async with container.enter_scope("request"):
                 await container.aresolve(AsyncCircularX)
 
         assert "AsyncCircularX" in str(exc_info.value)
@@ -313,7 +313,7 @@ class TestAsyncCircularDependencies:
         assert _current_scope.get() is None
 
         try:
-            async with container.start_scope("request"):
+            async with container.enter_scope("request"):
                 await container.aresolve(AsyncCircularX)
         except DIWireCircularDependencyError:
             pass

--- a/tests/test_circular_dependencies.py
+++ b/tests/test_circular_dependencies.py
@@ -175,12 +175,12 @@ class TestScopedCircularDependencies:
         container.register(
             ScopedCircularA,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.register(
             ScopedCircularB,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         with pytest.raises(DIWireCircularDependencyError) as exc_info:
@@ -195,7 +195,7 @@ class TestScopedCircularDependencies:
         container.register(
             ScopedToSingletonA,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.register(ScopedToSingletonB, lifetime=Lifetime.SINGLETON)
 
@@ -211,7 +211,7 @@ class TestScopedCircularDependencies:
         container.register(
             ScopedToTransientA,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.register(ScopedToTransientB, lifetime=Lifetime.TRANSIENT)
 
@@ -227,12 +227,12 @@ class TestScopedCircularDependencies:
         container.register(
             ScopedCircularA,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.register(
             ScopedCircularB,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         assert _current_scope.get() is None
@@ -280,12 +280,12 @@ class TestAsyncCircularDependencies:
         container.register(
             AsyncCircularX,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.register(
             AsyncCircularY,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         with pytest.raises(DIWireCircularDependencyError) as exc_info:
@@ -302,12 +302,12 @@ class TestAsyncCircularDependencies:
         container.register(
             AsyncCircularX,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.register(
             AsyncCircularY,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         assert _current_scope.get() is None

--- a/tests/test_compiled_providers.py
+++ b/tests/test_compiled_providers.py
@@ -102,7 +102,7 @@ class TestScopedSingletonProvider:
     def test_scoped_singleton_same_instance_in_scope(self) -> None:
         """Scoped singleton should return same instance within scope."""
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         with container.enter_scope("request"):
@@ -114,7 +114,7 @@ class TestScopedSingletonProvider:
     def test_scoped_singleton_different_instances_different_scopes(self) -> None:
         """Scoped singleton should return different instances in different scopes."""
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         with container.enter_scope("request"):
@@ -131,7 +131,7 @@ class TestScopedSingletonProvider:
         # Note: The current implementation creates instances even outside scope
         # using the ScopedSingletonProvider.__call__ fallback
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         # This tests the fallback path when scoped_cache is None
@@ -155,7 +155,7 @@ class TestScopedSingletonArgsProvider:
     def test_scoped_singleton_with_dependency_same_scope(self) -> None:
         """Scoped singleton with dependencies returns same instance in scope."""
         container = Container()
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         with container.enter_scope("request"):
@@ -171,7 +171,7 @@ class TestScopedSingletonArgsProvider:
     def test_scoped_singleton_with_deps_different_scopes(self) -> None:
         """Scoped singleton with deps gets different instances per scope."""
         container = Container()
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         with container.enter_scope("request"):
@@ -187,7 +187,7 @@ class TestScopedSingletonArgsProvider:
         """Test scoped singleton args provider fallback when outside scope."""
         container = Container()
         container.register(ServiceA, lifetime=Lifetime.TRANSIENT)
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         service_key_b = ServiceKey.from_value(ServiceB)
@@ -483,7 +483,7 @@ class TestCompiledProviderIntegration:
         container = Container()
         container.register(ServiceA, lifetime=Lifetime.SINGLETON)
         container.register(ServiceB, lifetime=Lifetime.TRANSIENT)
-        container.register(ServiceC, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceC, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         # Singleton behavior
@@ -556,7 +556,7 @@ class TestCompilationMissingCoverage:
         container.register(
             ServiceWithStr,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.compile()
 
@@ -580,7 +580,7 @@ class TestCompilationMissingCoverage:
         container.register(
             ServiceBLocal,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
         container.compile()
 
@@ -613,7 +613,7 @@ class TestCompilationMissingCoverage:
         service_key = ServiceKey.from_value(ScopedService)
 
         # Register the service for scope "scope_a"
-        container.register(ScopedService, lifetime=Lifetime.SCOPED_SINGLETON, scope="scope_a")
+        container.register(ScopedService, lifetime=Lifetime.SCOPED, scope="scope_a")
         container.compile()  # Creates compiled scoped provider for (service_key, "scope_a")
 
         # Manually create a scoped registration that will be found by _get_scoped_registration
@@ -621,7 +621,7 @@ class TestCompilationMissingCoverage:
         # This simulates an edge case where the registration scope differs from cache key lookup
         scoped_reg = Registration(
             service_key=service_key,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="scope_a",
         )
         # Put it in the scoped registry under "scope_b" so it's found when in scope_b
@@ -668,7 +668,7 @@ class TestCompilationMissingCoverage:
         container.register(
             ServiceWithBadDep,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         # Compilation should not raise - it returns None for this registration

--- a/tests/test_compiled_providers.py
+++ b/tests/test_compiled_providers.py
@@ -105,7 +105,7 @@ class TestScopedSingletonProvider:
         container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
         container.compile()
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance1 = container.resolve(ServiceA)
             instance2 = container.resolve(ServiceA)
 
@@ -117,10 +117,10 @@ class TestScopedSingletonProvider:
         container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
         container.compile()
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance1 = container.resolve(ServiceA)
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance2 = container.resolve(ServiceA)
 
         assert instance1 is not instance2
@@ -158,7 +158,7 @@ class TestScopedSingletonArgsProvider:
         container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
         container.compile()
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             # Resolve ServiceB multiple times - should be same instance
             service_b1 = container.resolve(ServiceB)
             service_b2 = container.resolve(ServiceB)
@@ -174,10 +174,10 @@ class TestScopedSingletonArgsProvider:
         container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
         container.compile()
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             service_b1 = container.resolve(ServiceB)
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             service_b2 = container.resolve(ServiceB)
 
         assert service_b1 is not service_b2
@@ -499,7 +499,7 @@ class TestCompiledProviderIntegration:
         assert transient_b1.service_a is transient_b2.service_a
 
         # Scoped behavior
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             scoped_c1 = container.resolve(ServiceC)
             scoped_c2 = container.resolve(ServiceC)
             assert scoped_c1 is scoped_c2
@@ -631,7 +631,7 @@ class TestCompilationMissingCoverage:
         # but scoped_registration.scope is "scope_a"
         # So cache_scope = current_scope.get_cache_key_for_scope("scope_a") returns None
         # because scope_b doesn't contain scope_a
-        with container.start_scope("scope_b"):
+        with container.enter_scope("scope_b"):
             # The scoped_provider exists for (service_key, "scope_a") from compilation
             # But cache_scope is None -> falls through branch 1107->1120
             # Then normal resolution finds the registration and raises scope mismatch
@@ -648,7 +648,7 @@ class TestCompilationMissingCoverage:
         container.register(ServiceLocal, scope="request", lifetime=Lifetime.TRANSIENT)
         container.compile()
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             # Each resolution should return a new instance (not cached)
             instance1 = container.resolve(ServiceLocal)
             instance2 = container.resolve(ServiceLocal)

--- a/tests/test_concrete_class.py
+++ b/tests/test_concrete_class.py
@@ -202,7 +202,7 @@ class TestConcreteClassWithLifetime:
             scope="request",
         )
 
-        with container.start_scope("request") as scope:
+        with container.enter_scope("request") as scope:
             result1 = scope.resolve(IService)
             result2 = scope.resolve(IService)
 
@@ -210,7 +210,7 @@ class TestConcreteClassWithLifetime:
             assert result1 is result2
 
         # New scope creates new instance
-        with container.start_scope("request") as scope:
+        with container.enter_scope("request") as scope:
             result3 = scope.resolve(IService)
             assert result3 is not result1
 

--- a/tests/test_concrete_class.py
+++ b/tests/test_concrete_class.py
@@ -198,7 +198,7 @@ class TestConcreteClassWithLifetime:
         container.register(
             IService,
             concrete_class=ScopedService,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -802,7 +802,7 @@ class TestAsyncResolutionEdgeCases:
         container._registry[service_key] = registration
 
         # Resolve within a different scope - should raise scope mismatch
-        with container.start_scope("wrong_scope"):
+        with container.enter_scope("wrong_scope"):
             with pytest.raises(DIWireScopeMismatchError):
                 await container.aresolve(ServiceA)
 
@@ -822,7 +822,7 @@ class TestAsyncResolutionEdgeCases:
             lifetime=Lifetime.SCOPED_SINGLETON,
         )
 
-        async with container.start_scope("request"):
+        async with container.enter_scope("request"):
             result = await container.aresolve(ServiceA)
             assert result is specific_instance
 
@@ -845,7 +845,7 @@ class TestAsyncResolutionEdgeCases:
             scope="request",
         )
 
-        async with container.start_scope("request"):
+        async with container.enter_scope("request"):
             with pytest.raises(DIWireGeneratorFactoryUnsupportedLifetimeError):
                 await container.aresolve(ServiceA)
 
@@ -873,7 +873,7 @@ class TestAsyncResolutionEdgeCases:
             scope="request",
         )
 
-        async with container.start_scope("request"):
+        async with container.enter_scope("request"):
             result = await container.aresolve(ServiceA)
             assert isinstance(result, ServiceA)
 
@@ -985,7 +985,7 @@ class TestAsyncResolutionEdgeCases:
         )
 
         # Use sync context manager but call aresolve
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             result = container.resolve(ServiceA)
             assert isinstance(result, ServiceA)
 
@@ -1071,7 +1071,7 @@ class TestMissingCoverageSync:
             scope="request",
         )
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             with pytest.raises(DIWireGeneratorFactoryUnsupportedLifetimeError):
                 container.resolve(ServiceA)
 
@@ -1096,7 +1096,7 @@ class TestMissingCoverageSync:
             None,
         )
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             with pytest.raises(DIWireGeneratorFactoryUnsupportedLifetimeError):
                 handler(generator_factory())
 
@@ -1122,7 +1122,7 @@ class TestMissingCoverageSync:
             None,
         )
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             with pytest.raises(DIWireGeneratorFactoryDidNotYieldError):
                 handler(generator_factory())
 
@@ -1151,7 +1151,7 @@ class TestMissingCoverageSync:
             None,
         )
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance = handler(generator_factory())
             assert isinstance(instance, ServiceA)
             assert cleanup == []
@@ -1333,7 +1333,7 @@ class TestCoverageEdgeCases:
         service_key_b = ServiceKey.from_value(ServiceB)
         assert (service_key_b, "request") not in container._scoped_compiled_providers
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             resolved = container.resolve(ServiceB)
             assert resolved.a is scoped_instance
 
@@ -1353,7 +1353,7 @@ class TestCoverageEdgeCases:
         assert (service_key, "request") in container._scoped_compiled_providers
 
         # Enter the matching scope - compiled provider path will be used
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance1 = container.resolve(ServiceA)
             instance2 = container.resolve(ServiceA)
 
@@ -1418,7 +1418,7 @@ class TestCoverageEdgeCases:
             scope="request",
         )
 
-        async with container.start_scope("request"):
+        async with container.enter_scope("request"):
             # Inside scope, cache_scope is not None, so we hit line 1407
             with pytest.raises(DIWireGeneratorFactoryUnsupportedLifetimeError):
                 await container.aresolve(ServiceA)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -685,7 +685,7 @@ class TestCompilationEdgeCases:
         string_key = ServiceKey(value="string_scoped_key", component=None)
         registration = Registration(
             service_key=string_key,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
         container._scoped_registry[(string_key, "request")] = registration
@@ -707,7 +707,7 @@ class TestCompilationEdgeCases:
                 self.a = a
 
         container.register(ServiceA, lifetime=Lifetime.TRANSIENT)
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
 
         container.compile()
 
@@ -796,7 +796,7 @@ class TestAsyncResolutionEdgeCases:
         service_key = ServiceKey.from_value(ServiceA)
         registration = Registration(
             service_key=service_key,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
         container._registry[service_key] = registration
@@ -819,7 +819,7 @@ class TestAsyncResolutionEdgeCases:
             ServiceA,
             instance=specific_instance,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         async with container.enter_scope("request"):
@@ -869,7 +869,7 @@ class TestAsyncResolutionEdgeCases:
         container.register(
             ServiceA,
             factory=generator_factory,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 
@@ -980,7 +980,7 @@ class TestAsyncResolutionEdgeCases:
         container.register(
             ServiceA,
             factory=generator_factory,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 
@@ -1004,7 +1004,7 @@ class TestAsyncResolutionEdgeCases:
             ServiceA,
             instance=specific_instance,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         # Create a scope context
@@ -1032,7 +1032,7 @@ class TestAsyncResolutionEdgeCases:
                 self.a = a
 
         # Register ServiceB with scope but don't register ServiceA
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
 
         # _find_scope_in_dependencies should handle the DIWireError gracefully
         # when checking nested deps of unregistered ServiceA
@@ -1085,7 +1085,7 @@ class TestMissingCoverageSync:
             pass
 
         container = Container()
-        container.register(ScopedMarker, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ScopedMarker, scope="request", lifetime=Lifetime.SCOPED)
 
         def generator_factory() -> Generator[ServiceA, None, None]:
             yield ServiceA()
@@ -1110,7 +1110,7 @@ class TestMissingCoverageSync:
             pass
 
         container = Container()
-        container.register(ScopedMarker, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ScopedMarker, scope="request", lifetime=Lifetime.SCOPED)
 
         def generator_factory() -> Generator[ServiceA, None, None]:
             return
@@ -1137,7 +1137,7 @@ class TestMissingCoverageSync:
 
         cleanup: list[str] = []
         container = Container()
-        container.register(ScopedMarker, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ScopedMarker, scope="request", lifetime=Lifetime.SCOPED)
 
         def generator_factory() -> Generator[ServiceA, None, None]:
             try:
@@ -1227,7 +1227,7 @@ class TestCoverageEdgeCases:
         service_key_b = ServiceKey.from_value(ServiceB)
         registration = Registration(
             service_key=service_key_b,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 
@@ -1271,7 +1271,7 @@ class TestCoverageEdgeCases:
         class ServiceA:
             pass
 
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         # Scoped registrations are skipped in _compiled_providers
@@ -1295,7 +1295,7 @@ class TestCoverageEdgeCases:
         # Only register ServiceB (scoped), but NOT ServiceA
         # When compiling ServiceB, _compile_or_get_provider(ServiceA) will return None
         # because ServiceA is not in _compiled_providers, not in _registry, and auto_register is disabled
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
 
         container.compile()
 
@@ -1324,9 +1324,9 @@ class TestCoverageEdgeCases:
             ServiceA,
             instance=scoped_instance,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
 
         container.compile()
 
@@ -1345,7 +1345,7 @@ class TestCoverageEdgeCases:
             pass
 
         # Register scoped singleton
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
         container.compile()
 
         # Verify compiled scoped provider exists
@@ -1461,7 +1461,7 @@ class TestCoverageEdgeCases:
             pass
 
         # Register a scoped singleton at "request" scope
-        container.register(Session, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
 
         # Create a scope ID with an anonymous segment (name=None)
         # This simulates entering nested scopes where inner one is anonymous
@@ -1488,7 +1488,7 @@ class TestCoverageEdgeCases:
                 self.a = a
 
         # Register ServiceB with scope but don't register ServiceA
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
 
         # Create a function that depends on ServiceB
         def handler(b: Annotated[ServiceB, Injected()]) -> ServiceB:

--- a/tests/test_container_context.py
+++ b/tests/test_container_context.py
@@ -2823,3 +2823,54 @@ class TestDeferredRegistrationWithTypeKey:
         finally:
             _current_container.reset(initial_token)
             container_context._deferred_registrations.clear()
+
+
+# ============================================================================
+# Close/AClose Method Tests
+# ============================================================================
+
+
+class TestContainerContextClose:
+    """Tests for close/aclose methods on ContainerContextProxy."""
+
+    def test_close_delegates_to_current_container(self) -> None:
+        """close() delegates to the current container's close method."""
+        proxy = ContainerContextProxy()
+        container = Container()
+        token = proxy.set_current(container)
+        try:
+            proxy.close()
+            assert container._closed
+        finally:
+            proxy.reset(token)
+
+    async def test_aclose_delegates_to_current_container(self) -> None:
+        """aclose() delegates to the current container's aclose method."""
+        proxy = ContainerContextProxy()
+        container = Container()
+        token = proxy.set_current(container)
+        try:
+            await proxy.aclose()
+            assert container._closed
+        finally:
+            proxy.reset(token)
+
+    def test_close_without_container_raises_error(self) -> None:
+        """close() raises DIWireContainerNotSetError when no container set."""
+        proxy = ContainerContextProxy()
+        token = _current_container.set(None)
+        try:
+            with pytest.raises(DIWireContainerNotSetError):
+                proxy.close()
+        finally:
+            _current_container.reset(token)
+
+    async def test_aclose_without_container_raises_error(self) -> None:
+        """aclose() raises DIWireContainerNotSetError when no container set."""
+        proxy = ContainerContextProxy()
+        token = _current_container.set(None)
+        try:
+            with pytest.raises(DIWireContainerNotSetError):
+                await proxy.aclose()
+        finally:
+            _current_container.reset(token)

--- a/tests/test_container_context.py
+++ b/tests/test_container_context.py
@@ -189,14 +189,14 @@ class TestProxyMethodDelegation:
         finally:
             container_context.reset(token)
 
-    def test_start_scope_delegates_to_container(self) -> None:
-        """start_scope() delegates to the current container."""
+    def test_enter_scope_delegates_to_container(self) -> None:
+        """enter_scope() delegates to the current container."""
         container = Container()
         container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
 
         token = container_context.set_current(container)
         try:
-            with container_context.start_scope("request"):
+            with container_context.enter_scope("request"):
                 service = container.resolve(ServiceA)
                 assert isinstance(service, ServiceA)
         finally:
@@ -789,7 +789,7 @@ class TestDirectTypeResolution:
 
         token = container_context.set_current(container)
         try:
-            with container_context.start_scope("request"):
+            with container_context.enter_scope("request"):
                 service = container_context.resolve(ServiceA, scope="request")
                 assert isinstance(service, ServiceA)
         finally:
@@ -1276,11 +1276,11 @@ class TestEdgeCases:
 
         token = container_context.set_current(container)
         try:
-            with container_context.start_scope("outer") as outer:
+            with container_context.enter_scope("outer") as outer:
                 service_a = container_context.resolve(ServiceA)
                 assert isinstance(service_a, ServiceA)
 
-                with outer.start_scope("inner"):
+                with outer.enter_scope("inner"):
                     service_b = container_context.resolve(ServiceB)
                     assert isinstance(service_b, ServiceB)
 
@@ -1573,12 +1573,12 @@ class TestContainerOperationsWithoutContainer:
             _current_container.reset(initial_token)
             container_context._deferred_registrations.clear()
 
-    def test_start_scope_without_container_raises_error(self) -> None:
-        """start_scope() without container raises DIWireContainerNotSetError."""
+    def test_enter_scope_without_container_raises_error(self) -> None:
+        """enter_scope() without container raises DIWireContainerNotSetError."""
         initial_token = _current_container.set(None)
         try:
             with pytest.raises(DIWireContainerNotSetError):
-                container_context.start_scope("request")
+                container_context.enter_scope("request")
         finally:
             _current_container.reset(initial_token)
 

--- a/tests/test_container_context.py
+++ b/tests/test_container_context.py
@@ -192,7 +192,7 @@ class TestProxyMethodDelegation:
     def test_enter_scope_delegates_to_container(self) -> None:
         """enter_scope() delegates to the current container."""
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
 
         token = container_context.set_current(container)
         try:
@@ -400,7 +400,7 @@ class TestDecoratorPatternSync:
     def test_decorated_function_with_scoped_singleton(self) -> None:
         """Decorated function with scope creates scope per call."""
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
 
         token = container_context.set_current(container)
         try:
@@ -473,7 +473,7 @@ class TestDecoratorPatternAsync:
     async def test_async_decorated_function_with_scope(self) -> None:
         """Async decorated function with scope creates scope per call."""
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
 
         token = container_context.set_current(container)
         try:
@@ -785,7 +785,7 @@ class TestDirectTypeResolution:
     def test_resolve_type_with_scope(self) -> None:
         """container_context.resolve(Type, scope="...") works."""
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
 
         token = container_context.set_current(container)
         try:
@@ -1136,7 +1136,7 @@ class TestFastAPILikeIntegration:
 
             # Set up container
             container = Container()
-            container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+            container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
             token = container_context.set_current(container)
             try:
                 result1 = endpoint1()
@@ -1271,8 +1271,8 @@ class TestEdgeCases:
     def test_nested_scopes_work_correctly(self) -> None:
         """Nested scopes through container_context work."""
         container = Container()
-        container.register(ServiceA, scope="outer", lifetime=Lifetime.SCOPED_SINGLETON)
-        container.register(ServiceB, scope="inner", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="outer", lifetime=Lifetime.SCOPED)
+        container.register(ServiceB, scope="inner", lifetime=Lifetime.SCOPED)
 
         token = container_context.set_current(container)
         try:
@@ -1947,10 +1947,10 @@ class TestLifetimeVariations:
         finally:
             container_context.reset(token)
 
-    def test_scoped_singleton_same_scope(self) -> None:
-        """SCOPED_SINGLETON returns same instance within same scope."""
+    def test_scoped_same_scope(self) -> None:
+        """SCOPED returns same instance within same scope."""
         container = Container()
-        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED_SINGLETON)
+        container.register(ServiceA, scope="request", lifetime=Lifetime.SCOPED)
 
         token = container_context.set_current(container)
         try:

--- a/tests/test_container_register.py
+++ b/tests/test_container_register.py
@@ -584,7 +584,7 @@ class TestRegisterAsyncFactory:
             ServiceA,
             factory=async_gen_factory,
             scope="test",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         async with container.enter_scope("test"):
@@ -648,7 +648,7 @@ class TestFactoryFunctionAutoInjectsDependencies:
             Service,
             factory=service_factory,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         async with container.enter_scope("request"):
@@ -758,7 +758,7 @@ class TestFactoryFunctionAutoInjectsDependencies:
             Service,
             factory=service_factory,
             scope="request",
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
         )
 
         with container.enter_scope("request"):
@@ -972,9 +972,9 @@ class TestRegisterClassAsDecorator:
         assert instance.do_something() == "implemented"
 
     def test_decorator_with_scope(self, container: Container) -> None:
-        """@container.register(lifetime=SCOPED_SINGLETON, scope=...) should work."""
+        """@container.register(lifetime=SCOPED, scope=...) should work."""
 
-        @container.register(lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+        @container.register(lifetime=Lifetime.SCOPED, scope="request")
         class RequestService:
             pass
 
@@ -983,13 +983,13 @@ class TestRegisterClassAsDecorator:
             instance2 = container.resolve(RequestService)
             assert instance1 is instance2
 
-    def test_decorator_scoped_singleton_without_scope_raises(self, container: Container) -> None:
-        """SCOPED_SINGLETON without scope should raise error."""
-        from diwire.exceptions import DIWireScopedSingletonWithoutScopeError
+    def test_decorator_scoped_without_scope_raises(self, container: Container) -> None:
+        """SCOPED without scope should raise error."""
+        from diwire.exceptions import DIWireScopedWithoutScopeError
 
-        with pytest.raises(DIWireScopedSingletonWithoutScopeError):
+        with pytest.raises(DIWireScopedWithoutScopeError):
 
-            @container.register(lifetime=Lifetime.SCOPED_SINGLETON)
+            @container.register(lifetime=Lifetime.SCOPED)
             class InvalidService:
                 pass
 
@@ -1532,7 +1532,7 @@ class TestAsyncGeneratorFactoryDecorator:
         class AsyncResource:
             pass
 
-        @container.register(lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+        @container.register(lifetime=Lifetime.SCOPED, scope="request")
         async def create_async_resource() -> AsyncGenerator[AsyncResource, None]:
             try:
                 yield AsyncResource()
@@ -1559,7 +1559,7 @@ class TestSyncGeneratorFactoryDecorator:
         class SyncResource:
             pass
 
-        @container.register(lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+        @container.register(lifetime=Lifetime.SCOPED, scope="request")
         def create_sync_resource() -> Generator[SyncResource, None, None]:
             try:
                 yield SyncResource()
@@ -1692,7 +1692,7 @@ class TestStaticMethodDecorator:
 
         class Factories:
             @staticmethod
-            @container.register(lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+            @container.register(lifetime=Lifetime.SCOPED, scope="request")
             async def create_resource() -> AsyncGenerator[Resource, None]:
                 try:
                     yield Resource()

--- a/tests/test_container_register.py
+++ b/tests/test_container_register.py
@@ -400,12 +400,12 @@ class TestRegisterWithInstance:
 
     def test_reregister_instance_in_nested_scope(self, container: Container) -> None:
         """Re-registering instance in nested scope should work correctly."""
-        with container.start_scope("outer") as outer:
+        with container.enter_scope("outer") as outer:
             c1 = outer.resolve(Container)
             c1.register(int, instance=1)
             assert c1.resolve(int) == 1
 
-            with outer.start_scope("inner") as inner:
+            with outer.enter_scope("inner") as inner:
                 c2 = inner.resolve(Container)
                 c2.register(int, instance=2)
                 assert c2.resolve(int) == 2
@@ -587,7 +587,7 @@ class TestRegisterAsyncFactory:
             lifetime=Lifetime.SCOPED_SINGLETON,
         )
 
-        async with container.start_scope("test"):
+        async with container.enter_scope("test"):
             instance = await container.aresolve(ServiceA)
             assert isinstance(instance, ServiceA)
             assert cleanup_called == []
@@ -651,7 +651,7 @@ class TestFactoryFunctionAutoInjectsDependencies:
             lifetime=Lifetime.SCOPED_SINGLETON,
         )
 
-        async with container.start_scope("request"):
+        async with container.enter_scope("request"):
             instance = await container.aresolve(Service)
             assert isinstance(instance, Service)
             assert received_request[0] is expected_request
@@ -761,7 +761,7 @@ class TestFactoryFunctionAutoInjectsDependencies:
             lifetime=Lifetime.SCOPED_SINGLETON,
         )
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance = container.resolve(Service)
             assert isinstance(instance, Service)
             assert received_request[0] is expected_request
@@ -978,7 +978,7 @@ class TestRegisterClassAsDecorator:
         class RequestService:
             pass
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance1 = container.resolve(RequestService)
             instance2 = container.resolve(RequestService)
             assert instance1 is instance2
@@ -1539,7 +1539,7 @@ class TestAsyncGeneratorFactoryDecorator:
             finally:
                 cleanup_called.append(True)
 
-        async with container.start_scope("request"):
+        async with container.enter_scope("request"):
             instance = await container.aresolve(AsyncResource)
             assert isinstance(instance, AsyncResource)
             assert cleanup_called == []
@@ -1566,7 +1566,7 @@ class TestSyncGeneratorFactoryDecorator:
             finally:
                 cleanup_called.append(True)
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             instance = container.resolve(SyncResource)
             assert isinstance(instance, SyncResource)
             assert cleanup_called == []
@@ -1699,7 +1699,7 @@ class TestStaticMethodDecorator:
                 finally:
                     cleanup_called.append(True)
 
-        async with container.start_scope("request"):
+        async with container.enter_scope("request"):
             instance = await container.aresolve(Resource)
             assert isinstance(instance, Resource)
             assert cleanup_called == []

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -186,7 +186,7 @@ class TestDecoratorFunctionality:
         """Each call creates new scope (for scoped decorator)."""
         container.register(
             ServiceA,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="test",
         )
 
@@ -199,11 +199,11 @@ class TestDecoratorFunctionality:
         # Different scopes should produce different instances
         assert result1 is not result2
 
-    def test_decorator_scoped_singleton_shares_within_call(self, container: Container) -> None:
-        """SCOPED_SINGLETON shared within same call."""
+    def test_decorator_scoped_shares_within_call(self, container: Container) -> None:
+        """SCOPED shared within same call."""
         container.register(
             ServiceA,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="test",
         )
 
@@ -254,7 +254,7 @@ class TestDecoratorAsync:
         """Each await creates new scope."""
         container.register(
             ServiceA,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="test",
         )
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -360,7 +360,7 @@ class TestGeneratorFactoryExceptions:
 
         # Generator factories require a scope - trying to resolve will fail
         # because either there's no scope (DIWireGeneratorFactoryWithoutScopeError)
-        # or the lifetime is not SCOPED_SINGLETON (DIWireGeneratorFactoryUnsupportedLifetimeError)
+        # or the lifetime is not SCOPED (DIWireGeneratorFactoryUnsupportedLifetimeError)
         with pytest.raises(  # type: ignore[call-overload]
             (
                 DIWireGeneratorFactoryUnsupportedLifetimeError,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -338,7 +338,7 @@ class TestGeneratorFactoryExceptions:
         container.register(ServiceA, factory=empty_generator_factory, scope="request")
 
         with pytest.raises(DIWireGeneratorFactoryDidNotYieldError):
-            with container.start_scope("request"):
+            with container.enter_scope("request"):
                 container.resolve(ServiceA)
 
     def test_generator_factory_unsupported_lifetime_raised(self) -> None:
@@ -383,7 +383,7 @@ class TestGeneratorFactoryExceptions:
         container.register(ServiceA, factory=empty_async_gen_factory, scope="request")
 
         with pytest.raises(DIWireAsyncGeneratorFactoryDidNotYieldError):
-            async with container.start_scope("request"):
+            async with container.enter_scope("request"):
                 await container.aresolve(ServiceA)
 
     async def test_async_generator_factory_unsupported_lifetime_raised(self) -> None:

--- a/tests/test_injected.py
+++ b/tests/test_injected.py
@@ -531,7 +531,7 @@ class TestInjectedMethodDecoration:
 
         handler = MyHandler("handler-1")
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             result = handler.handle()
             assert result[0] == "handler-1"
             assert isinstance(result[1], ScopedService)
@@ -588,7 +588,7 @@ class TestInjectedMethodDecoration:
 
         handler = AsyncHandler("/api/async")
 
-        async with container.start_scope("async-request"):
+        async with container.enter_scope("async-request"):
             result = await handler.process()
             assert result[0] == "/api/async"
             assert isinstance(result[1], AsyncScopedService)
@@ -799,7 +799,7 @@ class TestInjectedMethodDecoration:
 
         handler = RequestHandler("/api/users")
 
-        with container.start_scope("request"):
+        with container.enter_scope("request"):
             result = handler.response
             assert result[0] == "/api/users"
             assert isinstance(result[1], ScopedDep)

--- a/tests/test_injected.py
+++ b/tests/test_injected.py
@@ -514,7 +514,7 @@ class TestInjectedMethodDecoration:
 
         container.register(
             ScopedService,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 
@@ -571,7 +571,7 @@ class TestInjectedMethodDecoration:
 
         container.register(
             AsyncScopedService,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="async-request",
         )
 
@@ -780,7 +780,7 @@ class TestInjectedMethodDecoration:
         class ScopedDep:
             pass
 
-        container.register(ScopedDep, lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+        container.register(ScopedDep, lifetime=Lifetime.SCOPED, scope="request")
 
         class RequestHandler:
             def __init__(self, path: str) -> None:

--- a/tests/test_open_generics.py
+++ b/tests/test_open_generics.py
@@ -328,7 +328,7 @@ def test_open_generic_resolution_in_anonymous_scope(container: Container) -> Non
 
     decorator(create_box)
 
-    with container.start_scope():
+    with container.enter_scope():
         assert container.resolve(Box[int]).value == "int"
 
 
@@ -338,7 +338,7 @@ def test_scoped_open_generic_registration_skips_anonymous_scope(
     class Box(Generic[T]):
         pass
 
-    with container.start_scope() as scope:
+    with container.enter_scope() as scope:
         result = container._get_scoped_open_generic_registration(
             Box,
             None,
@@ -372,7 +372,7 @@ def test_open_generic_scoped_singleton(container: Container) -> None:
 
     decorator(create_box)
 
-    with container.start_scope("request"):
+    with container.enter_scope("request"):
         first = container.resolve(ScopedBox[int])
         second = container.resolve(ScopedBox[int])
         assert first is second

--- a/tests/test_open_generics.py
+++ b/tests/test_open_generics.py
@@ -362,7 +362,7 @@ def test_open_generic_scoped_singleton(container: Container) -> None:
         "Callable[[Callable[..., object]], Callable[..., object]]",
         container.register(
             scoped_key,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         ),
     )
@@ -426,7 +426,7 @@ def test_compile_skips_scoped_typevar_map_registrations(container: Container) ->
         service_key=service_key,
         factory=None,
         instance=None,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
         is_async=False,
         concrete_type=None,
@@ -445,7 +445,7 @@ def test_compile_skips_scoped_typevar_dependency(container: Container) -> None:
 
     container.register(
         ScopedTypevar,
-        lifetime=Lifetime.SCOPED_SINGLETON,
+        lifetime=Lifetime.SCOPED,
         scope="request",
     )
     container.compile()

--- a/tests/test_pep563_annotations.py
+++ b/tests/test_pep563_annotations.py
@@ -119,7 +119,7 @@ class TestPEP563ForwardReferences:
         container = Container()
         container.register(
             ForwardService,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 
@@ -139,7 +139,7 @@ class TestPEP563ForwardReferences:
         container = Container()
         container.register(
             ForwardService,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 
@@ -165,7 +165,7 @@ class TestPEP563ScopeDetection:
         # Register a scoped service (type defined later)
         container.register(
             ForwardService,
-            lifetime=Lifetime.SCOPED_SINGLETON,
+            lifetime=Lifetime.SCOPED,
             scope="request",
         )
 
@@ -230,7 +230,7 @@ class TestPEP563Resolution:
     def test_scoped_resolution_with_pep563(self) -> None:
         """Scoped resolution works with string annotations."""
         container = Container()
-        container.register(ServiceA, lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+        container.register(ServiceA, lifetime=Lifetime.SCOPED, scope="request")
 
         @container.resolve(scope="request")
         def handler(
@@ -244,7 +244,7 @@ class TestPEP563Resolution:
     async def test_async_scoped_resolution_with_pep563(self) -> None:
         """Async scoped resolution works with string annotations."""
         container = Container()
-        container.register(ServiceA, lifetime=Lifetime.SCOPED_SINGLETON, scope="request")
+        container.register(ServiceA, lifetime=Lifetime.SCOPED, scope="request")
 
         @container.resolve(scope="request")
         async def handler(

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -3044,6 +3044,21 @@ class TestContainerClosedError:
         with pytest.raises(DIWireContainerClosedError, match="closed container"):
             container.enter_scope("test")
 
+    def test_register_active_scope_on_closed_container_raises_error(
+        self,
+        container: Container,
+    ) -> None:
+        """Directly creating ScopedContainer on closed container raises error."""
+        from diwire.container import ScopedContainer, ScopeId
+        from diwire.exceptions import DIWireContainerClosedError
+
+        container.close()
+
+        scope_id = ScopeId(segments=((None, 1),))
+
+        with pytest.raises(DIWireContainerClosedError, match="closed container"):
+            ScopedContainer(container, scope_id)
+
 
 class TestImperativeScopeResourceCleanup:
     """Tests for resource cleanup with imperative scope management."""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,9 +15,9 @@ class TestLifetime:
         """SINGLETON has value 'singleton'."""
         assert Lifetime.SINGLETON.value == "singleton"
 
-    def test_lifetime_scoped_singleton_value(self) -> None:
-        """SCOPED_SINGLETON has value 'scoped_singleton'."""
-        assert Lifetime.SCOPED_SINGLETON.value == "scoped_singleton"
+    def test_lifetime_scoped_value(self) -> None:
+        """SCOPED has value 'scoped'."""
+        assert Lifetime.SCOPED.value == "scoped"
 
     def test_lifetime_is_enum(self) -> None:
         """Lifetime is an Enum."""
@@ -29,7 +29,7 @@ class TestLifetime:
         assert len(members) == 3
         assert Lifetime.TRANSIENT in members
         assert Lifetime.SINGLETON in members
-        assert Lifetime.SCOPED_SINGLETON in members
+        assert Lifetime.SCOPED in members
 
 
 class TestInjected:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit lifecycle controls: sync/async close, scope-close, and imperative scope activation via enter_scope.

* **Breaking Changes**
  * Scope entry API renamed from start_scope() to enter_scope().
  * Lifetime enum value SCOPED replaces SCOPED_SINGLETON.
  * Exception/messages updated to SCOPED terminology; new container-closed error added.

* **Documentation**
  * Examples and docs updated to reflect API renames and lifetime wording changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->