### PR TITLE
feat: introduce initial scope and add container interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ lint:
 test:
 	uv run pytest tests/ --benchmark-skip --cov=src/diwire --cov-report=term-missing
 
+test-all-pythons:
+	uv run --python 3.10 pytest tests/ --benchmark-skip --cov=src/diwire --cov-report=term-missing
+	uv run --python 3.14 pytest tests/ --benchmark-skip --cov=src/diwire --cov-report=term-missing
+	uv run --python 3.14t pytest tests/ --benchmark-skip --cov=src/diwire --cov-report=term-missing
+
 docs:
 	rm -rf docs/_build
 	uv run sphinx-build -b html docs docs/_build/html

--- a/docs/core/async.rst
+++ b/docs/core/async.rst
@@ -22,6 +22,8 @@ Async cleanup with async generators
 
 Use an **async generator** when you need to ``await`` cleanup (closing connections, sessions, etc.).
 The ``finally`` block runs when the scope exits.
+If you register an async generator factory without specifying a scope, it is attached to
+the initial app scope and cleaned up when you call ``container.aclose()``.
 
 See the runnable scripts in :doc:`/howto/examples/async` (Async generator cleanup section).
 

--- a/docs/core/errors.rst
+++ b/docs/core/errors.rst
@@ -33,6 +33,14 @@ Scope-related errors typically happen when:
 
 - you try to resolve a scoped service outside of its scope
 - you keep a reference to a scope and use it after it has exited
+- you resolve a generator factory when no scope is active (sync or async)
+
+By default, ``Container()`` starts with an active app scope, so generator factories
+registered without an explicit scope will use that initial scope and be cleaned up on
+``container.close()`` or ``container.aclose()``. If you see a
+``DIWireGeneratorFactoryWithoutScopeError`` or
+``DIWireAsyncGeneratorFactoryWithoutScopeError``, it usually means you're resolving in
+a context where no scope is active.
 
 See the runnable scripts in :doc:`/howto/examples/errors` (Scope mismatch section).
 

--- a/docs/core/lifetimes.rst
+++ b/docs/core/lifetimes.rst
@@ -41,6 +41,8 @@ Scoped
 ------
 
 Scoped lifetimes are covered in :doc:`scopes` because scopes also define *cleanup*.
+Generator factories without an explicit scope are attached to the initial app scope and
+cleaned up when you call ``container.close()`` or ``container.aclose()``.
 
 One important rule of thumb:
 

--- a/docs/core/registration.rst
+++ b/docs/core/registration.rst
@@ -20,6 +20,11 @@ The three direct registration forms:
 - **Factory**: ``container.register(Database, factory=create_database)``
 - **Instance**: ``container.register(Config, instance=Config(...))``
 
+Generator factories are supported for cleanup. If you omit a scope, the generator is
+attached to the initial app scope and cleaned up when you call ``container.close()``
+or ``container.aclose()``. Use ``Lifetime.SCOPED`` with a named scope to tie cleanup
+to a specific scope.
+
 Full runnable example:
 
 See :doc:`/howto/examples/basics` (Registration methods section).

--- a/docs/core/scopes.rst
+++ b/docs/core/scopes.rst
@@ -26,8 +26,13 @@ Scoped lifetime
 
 To share an instance *within* a scope, register it as ``Lifetime.SCOPED`` and provide a scope name:
 
-You can use predefined scope names like ``Scope.REQUEST`` (``app``, ``session``, ``request``) or provide any
-custom string name.
+The ``Scope`` enum provides three built-in scope names:
+
+- ``Scope.APP`` (``"app"``) -- application-wide scope (one per container or app lifetime)
+- ``Scope.SESSION`` (``"session"``) -- connection or session scope (e.g., websocket or user session)
+- ``Scope.REQUEST`` (``"request"``) -- request or job scope (one per request or unit of work)
+
+Scope parameters accept any string, so you can also provide a custom name like ``"tenant"`` or ``"task"``.
 
 See the runnable scripts in :doc:`/howto/examples/scopes` (SCOPED lifetime section).
 

--- a/docs/core/scopes.rst
+++ b/docs/core/scopes.rst
@@ -18,6 +18,9 @@ Scoped lifetime
 
 To share an instance *within* a scope, register it as ``Lifetime.SCOPED`` and provide a scope name:
 
+You can use predefined scope names like ``Scope.REQUEST`` (``app``, ``session``, ``request``) or provide any
+custom string name.
+
 See the runnable scripts in :doc:`/howto/examples/scopes` (SCOPED lifetime section).
 
 Generator factories (deterministic cleanup)

--- a/docs/core/scopes.rst
+++ b/docs/core/scopes.rst
@@ -36,6 +36,9 @@ Generator factories (deterministic cleanup)
 
 When you need cleanup (close a session, release a lock, return a connection to a pool), use a generator factory.
 diwire will close the generator when the scope exits, running your ``finally`` block.
+If you register a generator factory without specifying a scope, it is attached to the
+initial app scope and cleaned up when you call ``container.close()`` or
+``container.aclose()``.
 
 See the runnable scripts in :doc:`/howto/examples/scopes` (Generator factories section).
 

--- a/docs/core/scopes.rst
+++ b/docs/core/scopes.rst
@@ -13,6 +13,14 @@ Use :meth:`diwire.Container.enter_scope` as a context manager:
 
 See the runnable scripts in :doc:`/howto/examples/scopes` (Scope basics section).
 
+Initial app scope
+-----------------
+
+By default, ``Container()`` starts with an active app scope (``Scope.APP``).
+Calling ``enter_scope()`` creates a nested scope under that app scope.
+Close the initial app scope by calling ``container.close()`` or
+``container.aclose()``.
+
 Scoped lifetime
 ---------------
 

--- a/docs/howto/examples/async.rst
+++ b/docs/howto/examples/async.rst
@@ -15,7 +15,7 @@ Async factories are auto-detected (no special configuration needed).
 
    import asyncio
 
-   from diwire import Container, Lifetime
+   from diwire import Container, Lifetime, Scope
 
 
    class Database:
@@ -56,7 +56,7 @@ The cleanup code in the ``finally`` block runs automatically when the scope exit
 
    import asyncio
 
-   from diwire import Container, Lifetime
+   from diwire import Container, Lifetime, Scope
 
 
    class DatabaseSession:
@@ -85,10 +85,10 @@ The cleanup code in the ``finally`` block runs automatically when the scope exit
            DatabaseSession,
            factory=create_session,
            lifetime=Lifetime.SCOPED,
-           scope="request",
+           scope=Scope.REQUEST,
        )
 
-       async with container.enter_scope("request"):
+       async with container.enter_scope(Scope.REQUEST):
            session1 = await container.aresolve(DatabaseSession)
            session2 = await container.aresolve(DatabaseSession)
            print(f"same instance: {session1 is session2}")
@@ -152,7 +152,7 @@ Async scoped injection
 ----------------------
 
 Demonstrates ``AsyncScopedInjected``: resolving an async function with
-``scope="request"`` creates a new scope per invocation.
+``scope=Scope.REQUEST`` creates a new scope per invocation.
 
 .. code-block:: python
    :class: diwire-example py-run
@@ -160,7 +160,7 @@ Demonstrates ``AsyncScopedInjected``: resolving an async function with
    import asyncio
    from typing import Annotated
 
-   from diwire import Container, Injected, Lifetime
+   from diwire import Container, Injected, Lifetime, Scope
 
 
    class RequestContext:
@@ -184,10 +184,10 @@ Demonstrates ``AsyncScopedInjected``: resolving an async function with
        container.register(
            RequestContext,
            lifetime=Lifetime.SCOPED,
-           scope="request",
+           scope=Scope.REQUEST,
        )
 
-       per_request = await container.aresolve(handler, scope="request")
+       per_request = await container.aresolve(handler, scope=Scope.REQUEST)
        print(await per_request(payload={"n": "1"}))
        print(await per_request(payload={"n": "2"}))
 

--- a/docs/howto/examples/errors.rst
+++ b/docs/howto/examples/errors.rst
@@ -131,16 +131,8 @@ Demonstrates ``DIWireScopeMismatchError`` when trying to resolve from an exited 
 .. code-block:: python
    :class: diwire-example py-run
 
-   from enum import Enum
-
-   from diwire import Container, Lifetime
+   from diwire import Container, Lifetime, Scope
    from diwire.exceptions import DIWireScopeMismatchError
-
-
-   class Scope(str, Enum):
-       """Application scope definitions."""
-
-       REQUEST = "request"
 
 
    class RequestSession:
@@ -202,7 +194,7 @@ This prevents the container from silently auto-registering a second, unscoped in
 
    from dataclasses import dataclass
 
-   from diwire import Container, Lifetime
+   from diwire import Container, Lifetime, Scope
    from diwire.exceptions import DIWireScopeMismatchError
 
 
@@ -213,7 +205,7 @@ This prevents the container from silently auto-registering a second, unscoped in
 
    def main() -> None:
        container = Container(autoregister=True)
-       container.register(Session, lifetime=Lifetime.SCOPED, scope="request")
+       container.register(Session, lifetime=Lifetime.SCOPED, scope=Scope.REQUEST)
 
        print("Resolving a SCOPED service outside its scope:\n")
        try:
@@ -225,7 +217,7 @@ This prevents the container from silently auto-registering a second, unscoped in
            print(f"  current_scope: {e.current_scope}")
 
        print("\nResolving inside the correct scope:")
-       with container.enter_scope("request") as scope:
+       with container.enter_scope(Scope.REQUEST) as scope:
            session = scope.resolve(Session)
            print(f"  session.active={session.active}")
 

--- a/docs/howto/examples/fastapi.rst
+++ b/docs/howto/examples/fastapi.rst
@@ -29,12 +29,12 @@ integration:
 
    from fastapi import FastAPI, Request
 
-   from diwire import Container, Injected
+   from diwire import Container, Injected, Scope
    from diwire.integrations.fastapi import setup_diwire
 
    app = FastAPI()
    container = Container()
-   setup_diwire(app, container=container, scope="request")
+   setup_diwire(app, container=container, scope=Scope.REQUEST)
 
 
    @dataclass
@@ -63,7 +63,7 @@ integration:
        return {"message": service.greet(), "request_id": id(request)}
 
 
-   container.register(Service, factory=get_service, scope="request")
+   container.register(Service, factory=get_service, scope=Scope.REQUEST)
 
 
    @app.get("/greet")
@@ -80,7 +80,7 @@ This example demonstrates a 3-layer architecture:
 Key points:
 
 - all layers share the same scoped instances within a request
-- ``@container.resolve(scope="request")`` integrates cleanly with ``@app.get()``
+- ``@container.resolve(scope=Scope.REQUEST)`` integrates cleanly with ``@app.get()``
 - dependencies are resolved automatically via type hints
 
 .. code-block:: python
@@ -95,7 +95,7 @@ Key points:
    from fastapi import FastAPI
    from fastapi.params import Query
 
-   from diwire import Container, Injected
+   from diwire import Container, Injected, Scope
 
    app = FastAPI()
    container = Container()
@@ -145,12 +145,12 @@ Key points:
            print("Closing service")
 
 
-   container.register(Repository, factory=get_repository, scope="request")
-   container.register(Service, factory=get_service, scope="request")
+   container.register(Repository, factory=get_repository, scope=Scope.REQUEST)
+   container.register(Service, factory=get_service, scope=Scope.REQUEST)
 
 
    @app.get("/greet")
-   @container.resolve(scope="request")
+   @container.resolve(scope=Scope.REQUEST)
    async def greet(
        name: Annotated[str, Query()],
        service: Injected[Service],
@@ -187,7 +187,7 @@ Key concepts:
 
    from fastapi import FastAPI, Request
 
-   from diwire import Container, Injected, container_context
+   from diwire import Container, Injected, Scope, container_context
 
    app = FastAPI()
    request_context: ContextVar[Request] = ContextVar("request_context")
@@ -232,12 +232,12 @@ Key concepts:
        container = Container()
        container_context.set_current(container)
 
-       container.register(Request, factory=request_context.get, scope="request")
-       container.register(Service, factory=get_service, scope="request")
+       container.register(Request, factory=request_context.get, scope=Scope.REQUEST)
+       container.register(Service, factory=get_service, scope=Scope.REQUEST)
 
 
    @app.get("/greet")
-   @container_context.resolve(scope="request")
+   @container_context.resolve(scope=Scope.REQUEST)
    async def greet(
        name: str,
        service: Injected[Service],

--- a/docs/howto/examples/function-injection.rst
+++ b/docs/howto/examples/function-injection.rst
@@ -156,16 +156,9 @@ where each call needs its own scope.
 
    import random
    from dataclasses import dataclass
-   from enum import Enum
    from typing import Annotated
 
-   from diwire import Container, Injected, Lifetime
-
-
-   class Scope(str, Enum):
-       """Application scope definitions."""
-
-       REQUEST = "request"
+   from diwire import Container, Injected, Lifetime, Scope
 
 
    @dataclass

--- a/docs/howto/examples/patterns.rst
+++ b/docs/howto/examples/patterns.rst
@@ -11,19 +11,14 @@ Demonstrates a common web pattern:
 
 - each request gets its own scope
 - multiple services share a request-scoped context
-- the handler is resolved via ``container.resolve(..., scope="request")``
+- the handler is resolved via ``container.resolve(..., scope=Scope.REQUEST)``
 
 .. code-block:: python
    :class: diwire-example py-run
 
-   from enum import Enum
    from typing import Annotated
 
-   from diwire import Container, Injected, Lifetime
-
-
-   class Scope(str, Enum):
-       REQUEST = "request"
+   from diwire import Container, Injected, Lifetime, Scope
 
 
    class RequestContext:
@@ -96,7 +91,7 @@ Per-call unit of work (ScopedInjected)
    from diwire import Container, Injected, Lifetime
 
 
-   class Scope(str, Enum):
+   class UnitOfWorkScope(str, Enum):
        UNIT_OF_WORK = "unit_of_work"
 
 
@@ -132,10 +127,10 @@ Per-call unit of work (ScopedInjected)
 
    def main() -> None:
        container = Container()
-       container.register(Session, lifetime=Lifetime.SCOPED, scope=Scope.UNIT_OF_WORK)
+       container.register(Session, lifetime=Lifetime.SCOPED, scope=UnitOfWorkScope.UNIT_OF_WORK)
        container.register(UserRepository)
 
-       handler = container.resolve(create_user, scope=Scope.UNIT_OF_WORK)
+       handler = container.resolve(create_user, scope=UnitOfWorkScope.UNIT_OF_WORK)
        print(handler(username="alice"))
        print(handler(username="bob"))
 
@@ -157,7 +152,7 @@ Use ``enter_scope()`` when you want to manage the scope explicitly.
    from diwire import Container, Lifetime
 
 
-   class Scope(str, Enum):
+   class UnitOfWorkScope(str, Enum):
        UNIT_OF_WORK = "unit_of_work"
 
 
@@ -176,10 +171,10 @@ Use ``enter_scope()`` when you want to manage the scope explicitly.
 
    def main() -> None:
        container = Container()
-       container.register(Session, lifetime=Lifetime.SCOPED, scope=Scope.UNIT_OF_WORK)
+       container.register(Session, lifetime=Lifetime.SCOPED, scope=UnitOfWorkScope.UNIT_OF_WORK)
        container.register(UserRepository)
 
-       with container.enter_scope(Scope.UNIT_OF_WORK) as scope:
+       with container.enter_scope(UnitOfWorkScope.UNIT_OF_WORK) as scope:
            repo1 = scope.resolve(UserRepository)
            repo2 = scope.resolve(UserRepository)
            session = scope.resolve(Session)

--- a/docs/howto/examples/scopes.rst
+++ b/docs/howto/examples/scopes.rst
@@ -13,15 +13,7 @@ Scopes allow grouping related service resolutions together.
 .. code-block:: python
    :class: diwire-example py-run
 
-   from enum import Enum
-
-   from diwire import Container
-
-
-   class Scope(str, Enum):
-       """Application scope definitions."""
-
-       REQUEST = "request"
+   from diwire import Container, Scope
 
 
    class RequestContext:
@@ -79,15 +71,7 @@ Demonstrates ``SCOPED``:
 .. code-block:: python
    :class: diwire-example py-run
 
-   from enum import Enum
-
-   from diwire import Container, Lifetime
-
-
-   class Scope(str, Enum):
-       """Application scope definitions."""
-
-       REQUEST = "request"
+   from diwire import Container, Lifetime, Scope
 
 
    class Session:
@@ -156,16 +140,9 @@ from parent scopes.
 .. code-block:: python
    :class: diwire-example py-run
 
-   from enum import Enum
+   from diwire import Container, Lifetime, Scope
 
-   from diwire import Container, Lifetime
-
-
-   class Scope(str, Enum):
-       """Application scope definitions."""
-
-       REQUEST = "request"
-       HANDLER = "handler"
+   HANDLER = "handler"
 
 
    class RequestContext:
@@ -193,7 +170,7 @@ from parent scopes.
        container.register(
            HandlerContext,
            lifetime=Lifetime.SCOPED,
-           scope=Scope.HANDLER,
+           scope=HANDLER,
        )
 
        print("Nested scopes demonstration:\n")
@@ -203,7 +180,7 @@ from parent scopes.
            print(f"Request scope - RequestContext id: {request_ctx.request_id}")
 
            # Create nested handler scopes
-           with request_scope.enter_scope(Scope.HANDLER) as handler_scope1:
+           with request_scope.enter_scope(HANDLER) as handler_scope1:
                handler_ctx1 = handler_scope1.resolve(HandlerContext)
                # Parent's RequestContext is accessible from child
                inherited_request_ctx = handler_scope1.resolve(RequestContext)
@@ -213,7 +190,7 @@ from parent scopes.
                print(f"    RequestContext id: {inherited_request_ctx.request_id}")
                print(f"    Same request context: {inherited_request_ctx is request_ctx}")
 
-           with request_scope.enter_scope(Scope.HANDLER) as handler_scope2:
+           with request_scope.enter_scope(HANDLER) as handler_scope2:
                handler_ctx2 = handler_scope2.resolve(HandlerContext)
                inherited_request_ctx2 = handler_scope2.resolve(RequestContext)
 
@@ -241,15 +218,7 @@ Demonstrates generator factory support:
    from __future__ import annotations
 
    from collections.abc import Generator
-   from enum import Enum
-
-   from diwire import Container, Lifetime
-
-
-   class Scope(str, Enum):
-       """Application scope definitions."""
-
-       REQUEST = "request"
+   from diwire import Container, Lifetime, Scope
 
 
    class Session:

--- a/docs/howto/examples/scopes.rst
+++ b/docs/howto/examples/scopes.rst
@@ -212,6 +212,7 @@ Demonstrates generator factory support:
 
 - the yielded instance is used by the container
 - the generator is closed on scope exit
+
 If you omit a scope in ``register()``, the generator is attached to the initial app
 scope and cleaned up when you call ``container.close()`` or ``container.aclose()``.
 

--- a/docs/howto/examples/scopes.rst
+++ b/docs/howto/examples/scopes.rst
@@ -29,6 +29,7 @@ Scopes allow grouping related service resolutions together.
    def main() -> None:
        container = Container()
        container.register(RequestContext)
+       # Container starts with an active app scope by default.
 
        # Using enter_scope() with an Enum value
        print("Scope usage with context manager:\n")

--- a/docs/howto/examples/scopes.rst
+++ b/docs/howto/examples/scopes.rst
@@ -212,6 +212,8 @@ Demonstrates generator factory support:
 
 - the yielded instance is used by the container
 - the generator is closed on scope exit
+If you omit a scope in ``register()``, the generator is attached to the initial app
+scope and cleaned up when you call ``container.close()`` or ``container.aclose()``.
 
 .. code-block:: python
    :class: diwire-example py-run

--- a/docs/howto/patterns/request-scope.rst
+++ b/docs/howto/patterns/request-scope.rst
@@ -9,8 +9,8 @@ A "request scope" is the most common unit of work for DI in web apps.
 The pattern
 -----------
 
-1. Pick a scope name (commonly ``"request"``).
-2. Register request-local services with ``lifetime=Lifetime.SCOPED`` and ``scope="request"``.
+1. Pick a scope name (commonly ``Scope.REQUEST``).
+2. Register request-local services with ``lifetime=Lifetime.SCOPED`` and ``scope=Scope.REQUEST``.
 3. Enter the scope for each request and resolve your handler/service graph inside it.
 
 Example (runnable)

--- a/docs/howto/patterns/resources.rst
+++ b/docs/howto/patterns/resources.rst
@@ -5,6 +5,8 @@ Resources (cleanup)
 ===================
 
 When a dependency needs cleanup (close/dispose/release), register it as a scoped service using a generator factory.
+If you omit a scope, the generator is attached to the initial app scope and cleaned up
+when you call ``container.close()`` or ``container.aclose()``.
 
 Sync cleanup (generator)
 ------------------------

--- a/docs/howto/web/django.rst
+++ b/docs/howto/web/django.rst
@@ -12,7 +12,7 @@ Recommended pattern
 1. Create a global container at startup (for example in an app config or a module imported on startup).
 2. Add a Django middleware that:
 
-   - enters a ``"request"`` scope at the start of the request
+   - enters a ``Scope.REQUEST`` scope at the start of the request
    - closes it in a ``finally`` block
    - optionally stores the scope on the request object for manual resolution
 
@@ -28,11 +28,11 @@ Minimal sketch
 
    from django.http import HttpRequest
 
-   from diwire import Container, Injected, Lifetime
+   from diwire import Container, Injected, Lifetime, Scope
 
    container = Container()
    request_var: ContextVar[HttpRequest] = ContextVar("request_var")
-   container.register(HttpRequest, factory=request_var.get, scope="request")
+   container.register(HttpRequest, factory=request_var.get, scope=Scope.REQUEST)
 
 
    class DiwireMiddleware:
@@ -41,7 +41,7 @@ Minimal sketch
 
        def __call__(self, request):
            token = request_var.set(request)
-           scope = container.enter_scope("request")
+           scope = container.enter_scope(Scope.REQUEST)
            try:
                request.diwire_scope = scope  # optional: manual resolution from deep in the stack
                return self.get_response(request)
@@ -54,7 +54,7 @@ Minimal sketch
        ...
 
 
-   container.register(Service, lifetime=Lifetime.SCOPED, scope="request")
+   container.register(Service, lifetime=Lifetime.SCOPED, scope=Scope.REQUEST)
 
 
    @container.resolve()

--- a/docs/howto/web/fastapi.rst
+++ b/docs/howto/web/fastapi.rst
@@ -26,12 +26,12 @@ resolves the injected dependencies when the endpoint is called.
 
       from fastapi import FastAPI
 
-      from diwire import Container
+      from diwire import Container, Scope
       from diwire.integrations.fastapi import setup_diwire
 
       app = FastAPI()
       container = Container()
-      setup_diwire(app, container=container, scope="request")
+      setup_diwire(app, container=container, scope=Scope.REQUEST)
 
 2. Define routes normally (no explicit diwire decorator needed):
 
@@ -46,7 +46,7 @@ resolves the injected dependencies when the endpoint is called.
       async def health(service: Injected["Service"]) -> dict[str, str]:
           return {"status": service.ok()}
 
-3. Register request-scoped services (``Lifetime.SCOPED``, ``scope="request"``) and any request-specific objects
+3. Register request-scoped services (``Lifetime.SCOPED``, ``scope=Scope.REQUEST``) and any request-specific objects
    (like ``fastapi.Request``) via factories/contextvars.
 
 Router-level control
@@ -75,7 +75,7 @@ If you prefer to be explicit (or want to avoid the integration), you can wrap en
 
    from fastapi import FastAPI
 
-   from diwire import Container
+   from diwire import Container, Scope
 
    app = FastAPI()
    container = Container()
@@ -85,7 +85,7 @@ If you prefer to be explicit (or want to avoid the integration), you can wrap en
 
    app.add_api_route(
        "/path",
-       container.resolve(handler, scope="request"),
+       container.resolve(handler, scope=Scope.REQUEST),
        methods=["GET"],
    )
 
@@ -93,13 +93,13 @@ Or use decorator-based wrapping:
 
 .. code-block:: python
 
-   from diwire import Container
+   from diwire import Container, Scope
 
    container = Container()
 
 
    @app.get("/path")
-   @container.resolve(scope="request")
+   @container.resolve(scope=Scope.REQUEST)
    async def handler() -> dict: ...
 
 For larger applications, ``container_context`` can be used to avoid passing the container
@@ -107,10 +107,10 @@ everywhere:
 
 .. code-block:: python
 
-   from diwire import container_context
+   from diwire import Scope, container_context
 
    @app.get("/path")
-   @container_context.resolve(scope="request")
+   @container_context.resolve(scope=Scope.REQUEST)
    async def handler() -> dict: ...
 
 Runnable examples

--- a/docs/howto/web/flask.rst
+++ b/docs/howto/web/flask.rst
@@ -11,7 +11,7 @@ Recommended pattern
 -------------------
 
 1. Create a global container at app startup.
-2. Enter a ``"request"`` scope in ``before_request`` and close it in ``teardown_request``.
+2. Enter a ``Scope.REQUEST`` scope in ``before_request`` and close it in ``teardown_request``.
 3. Use ``container.resolve()`` (or ``container_context.resolve()``) to inject services into view functions.
 
 Minimal sketch
@@ -22,7 +22,7 @@ Minimal sketch
    from flask import Flask, g
    from typing import Annotated
 
-   from diwire import Container, Injected, Lifetime
+   from diwire import Container, Injected, Lifetime, Scope
 
    app = Flask(__name__)
    container = Container()
@@ -30,7 +30,7 @@ Minimal sketch
 
    @app.before_request
    def _enter_request_scope() -> None:
-       g.diwire_scope = container.enter_scope("request")
+       g.diwire_scope = container.enter_scope(Scope.REQUEST)
 
 
    @app.teardown_request
@@ -44,7 +44,7 @@ Minimal sketch
        ...
 
 
-   container.register(Service, lifetime=Lifetime.SCOPED, scope="request")
+   container.register(Service, lifetime=Lifetime.SCOPED, scope=Scope.REQUEST)
 
 
    @app.get("/health")
@@ -52,5 +52,5 @@ Minimal sketch
    def health(service: Injected[Service]) -> dict[str, bool]:
        return {"ok": True}
 
-If you'd rather have the wrapper create the scope per call, pass ``scope="request"`` to ``resolve()``, but the
+If you'd rather have the wrapper create the scope per call, pass ``scope=Scope.REQUEST`` to ``resolve()``, but the
 hook-based approach is usually a better match for Flask apps.

--- a/docs/howto/web/starlette.rst
+++ b/docs/howto/web/starlette.rst
@@ -22,7 +22,7 @@ Minimal sketch
    from starlette.requests import Request
    from starlette.responses import JSONResponse
 
-   from diwire import Container, Injected, container_context
+   from diwire import Container, Injected, Scope, container_context
 
    request_var: ContextVar[Request] = ContextVar("request_var")
    app = Starlette()
@@ -41,10 +41,10 @@ Minimal sketch
    container = Container()
    container_context.set_current(container)
 
-   container.register(Request, factory=request_var.get, scope="request")
+   container.register(Request, factory=request_var.get, scope=Scope.REQUEST)
 
 
-   @container_context.resolve(scope="request")
+   @container_context.resolve(scope=Scope.REQUEST)
    async def handler(
        request: Request,
        service: Injected["Service"],

--- a/docs/reference/container_interface.rst
+++ b/docs/reference/container_interface.rst
@@ -1,0 +1,5 @@
+IContainer
+==========
+
+.. autoclass:: diwire.IContainer
+   :members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -10,6 +10,7 @@ The public API is intentionally small and stable.
    :maxdepth: 2
 
    container
+   container_interface
    scopes
    context
    types

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -7,6 +7,12 @@ Lifetime
 .. autoclass:: diwire.Lifetime
    :members:
 
+Scope
+-----
+
+.. autoclass:: diwire.Scope
+   :members:
+
 Injected
 --------
 

--- a/src/diwire/__init__.py
+++ b/src/diwire/__init__.py
@@ -3,7 +3,7 @@ from diwire.container_context import container_context
 from diwire.container_interface import IContainer
 from diwire.container_scopes import ScopedContainer
 from diwire.service_key import Component
-from diwire.types import Injected, Lifetime
+from diwire.types import Injected, Lifetime, Scope
 
 __all__ = [
     "Component",
@@ -11,6 +11,7 @@ __all__ = [
     "IContainer",
     "Injected",
     "Lifetime",
+    "Scope",
     "ScopedContainer",
     "container_context",
 ]

--- a/src/diwire/__init__.py
+++ b/src/diwire/__init__.py
@@ -1,5 +1,6 @@
 from diwire.container import Container
 from diwire.container_context import container_context
+from diwire.container_interface import IContainer
 from diwire.container_scopes import ScopedContainer
 from diwire.service_key import Component
 from diwire.types import Injected, Lifetime
@@ -7,6 +8,7 @@ from diwire.types import Injected, Lifetime
 __all__ = [
     "Component",
     "Container",
+    "IContainer",
     "Injected",
     "Lifetime",
     "ScopedContainer",

--- a/src/diwire/container.py
+++ b/src/diwire/container.py
@@ -1432,8 +1432,7 @@ class Container(IContainer):
         if isinstance(result, AsyncGenerator):
             raise DIWireAsyncDependencyInSyncContextError(service_key, service_key)
         if isinstance(result, Generator):
-            current_scope = _current_scope.get() if self._has_scoped_registrations else None
-            cache_scope = self._get_cache_scope(current_scope, scope)
+            cache_scope = self._get_cache_scope(_current_scope.get(), scope)
             if cache_scope is None:
                 raise DIWireGeneratorFactoryWithoutScopeError(service_key)
             if lifetime == Lifetime.SINGLETON:
@@ -1933,6 +1932,11 @@ class Container(IContainer):
                         instance = registration.factory()
                     if isinstance(instance, Generator):
                         if cache_scope is None:
+                            cache_scope = self._get_cache_scope(
+                                _current_scope.get(),
+                                registration.scope,
+                            )
+                        if cache_scope is None:
                             raise DIWireGeneratorFactoryWithoutScopeError(service_key)
                         if registration.lifetime == Lifetime.SINGLETON:
                             raise DIWireGeneratorFactoryUnsupportedLifetimeError(service_key)
@@ -2316,6 +2320,11 @@ class Container(IContainer):
                     elif isinstance(result, AsyncGenerator):
                         # Async generator factory
                         if cache_scope is None:
+                            cache_scope = self._get_cache_scope(
+                                _current_scope.get(),
+                                registration.scope,
+                            )
+                        if cache_scope is None:
                             raise DIWireAsyncGeneratorFactoryWithoutScopeError(service_key)
                         if registration.lifetime == Lifetime.SINGLETON:
                             raise DIWireGeneratorFactoryUnsupportedLifetimeError(service_key)
@@ -2328,6 +2337,11 @@ class Container(IContainer):
                         async_exit_stack.push_async_callback(result.aclose)
                     elif isinstance(result, Generator):
                         # Sync generator factory
+                        if cache_scope is None:
+                            cache_scope = self._get_cache_scope(
+                                _current_scope.get(),
+                                registration.scope,
+                            )
                         if cache_scope is None:
                             raise DIWireGeneratorFactoryWithoutScopeError(service_key)
                         if registration.lifetime == Lifetime.SINGLETON:

--- a/src/diwire/container.py
+++ b/src/diwire/container.py
@@ -77,6 +77,7 @@ from diwire.exceptions import (
     DIWireGeneratorFactoryWithoutScopeError,
     DIWireIgnoredServiceError,
     DIWireInvalidGenericTypeArgumentError,
+    DIWireInvalidScopeNameError,
     DIWireMissingDependenciesError,
     DIWireNotAClassError,
     DIWireOpenGenericRegistrationError,
@@ -354,8 +355,7 @@ class Container(IContainer):
     ) -> None:
         normalized_scope = initial_scope.strip()
         if not normalized_scope:
-            message = "initial_scope must be a non-empty scope name."
-            raise ValueError(message)
+            raise DIWireInvalidScopeNameError(initial_scope)
         self._initial_scope_name = normalized_scope
         self._autoregister = autoregister
         self._autoregister_ignores = autoregister_ignores or DEFAULT_AUTOREGISTER_IGNORES

--- a/src/diwire/container.py
+++ b/src/diwire/container.py
@@ -51,6 +51,7 @@ from diwire.container_injection import (
     _InjectedFunction,
     _ScopedInjectedFunction,
 )
+from diwire.container_interface import IContainer
 from diwire.container_locks import LockManager
 from diwire.container_resolution_stack import _get_resolution_stack
 from diwire.container_scopes import ScopedContainer, _current_scope, _ScopeId
@@ -289,7 +290,7 @@ class _ScopedCacheView(MutableMapping[ServiceKey, Any]):
             return instance
 
 
-class Container:
+class Container(IContainer):
     """Dependency injection container for registering and resolving services.
 
     Supports automatic registration, lifetime singleton/transient, and factory patterns.

--- a/src/diwire/container_interface.py
+++ b/src/diwire/container_interface.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar, overload
+
+from diwire.types import Factory, Lifetime
+
+T = TypeVar("T")
+C = TypeVar("C", bound=type)
+
+
+class IContainer(ABC):
+    """Interface for container-like objects."""
+
+    # Overload 1: Bare class decorator - @container.register
+    @overload
+    @abstractmethod
+    def register(self, key: C, /) -> C: ...
+
+    # Overload 2: Bare factory function decorator - @container.register
+    @overload
+    @abstractmethod
+    def register(self, key: Callable[..., T], /) -> Callable[..., T]: ...
+
+    # Overload 3: Parameterized decorator without key - @container.register(lifetime=...)
+    @overload
+    @abstractmethod
+    def register(
+        self,
+        key: None = None,
+        /,
+        factory: None = None,
+        instance: None = None,
+        lifetime: Lifetime = ...,
+        scope: str | None = ...,
+        is_async: bool | None = ...,  # noqa: FBT001
+        concrete_class: type | None = ...,
+    ) -> Callable[[T], T]: ...
+
+    # Overload 4: Interface decorator - @container.register(Interface, lifetime=...)
+    @overload
+    @abstractmethod
+    def register(
+        self,
+        key: type,
+        /,
+        *,
+        lifetime: Lifetime = ...,
+        scope: str | None = ...,
+        is_async: bool | None = ...,
+    ) -> Callable[[T], T]: ...
+
+    # Overload 5: String key decorator - @container.register("key", lifetime=...)
+    @overload
+    @abstractmethod
+    def register(
+        self,
+        key: str,
+        /,
+        *,
+        lifetime: Lifetime = ...,
+        scope: str | None = ...,
+        is_async: bool | None = ...,
+    ) -> Callable[[T], T]: ...
+
+    # Overload 6: Direct call with explicit key - container.register(Interface, concrete_class=...)
+    @overload
+    @abstractmethod
+    def register(
+        self,
+        key: Any,
+        /,
+        factory: Factory | None = ...,
+        instance: Any | None = ...,
+        lifetime: Lifetime = ...,
+        scope: str | None = ...,
+        is_async: bool | None = ...,  # noqa: FBT001
+        concrete_class: type | None = ...,
+    ) -> None: ...
+
+    @abstractmethod
+    def register(  # noqa: PLR0913
+        self,
+        key: Any | None = None,
+        /,
+        factory: Factory | None = None,
+        instance: Any | None = None,
+        lifetime: Lifetime = Lifetime.TRANSIENT,
+        scope: str | None = None,
+        is_async: bool | None = None,  # noqa: FBT001
+        concrete_class: type | None = None,
+    ) -> Any:
+        """Register a service with the container."""
+
+    @overload
+    @abstractmethod
+    def resolve(
+        self,
+        key: None = None,
+        *,
+        scope: str,
+    ) -> Callable[[Callable[..., Any]], Any]: ...
+
+    @overload
+    @abstractmethod
+    def resolve(
+        self,
+        key: None = None,
+        *,
+        scope: None = None,
+    ) -> Callable[[Callable[..., Any]], Any]: ...
+
+    @overload
+    @abstractmethod
+    def resolve(self, key: type[T], *, scope: None = None) -> T: ...
+
+    @overload
+    @abstractmethod
+    def resolve(self, key: type[T], *, scope: str) -> T: ...
+
+    @overload
+    @abstractmethod
+    def resolve(
+        self,
+        key: Callable[..., Coroutine[Any, Any, T]],
+        *,
+        scope: None = None,
+    ) -> Any: ...
+
+    @overload
+    @abstractmethod
+    def resolve(
+        self,
+        key: Callable[..., Coroutine[Any, Any, T]],
+        *,
+        scope: str,
+    ) -> Any: ...
+
+    @overload
+    @abstractmethod
+    def resolve(self, key: Callable[..., T], *, scope: None = None) -> Any: ...
+
+    @overload
+    @abstractmethod
+    def resolve(self, key: Callable[..., T], *, scope: str) -> Any: ...
+
+    @overload
+    @abstractmethod
+    def resolve(self, key: Any, *, scope: str | None = None) -> Any: ...
+
+    @abstractmethod
+    def resolve(self, key: Any | None = None, *, scope: str | None = None) -> Any:
+        """Resolve a service or create a dependency-injected wrapper."""
+
+    @abstractmethod
+    def aresolve(self, key: type[T], *, scope: str | None = None) -> Coroutine[Any, Any, T]:
+        """Asynchronously resolve a service."""
+
+    @abstractmethod
+    def enter_scope(self, scope_name: str | None = None) -> IContainer:
+        """Start a new scope."""
+
+    @abstractmethod
+    def compile(self) -> None:
+        """Compile the container for optimized resolution."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the container."""
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        """Asynchronously close the container."""
+
+    @abstractmethod
+    def close_scope(self, scope_name: str) -> None:
+        """Close all active scopes that contain the given scope name."""
+
+    @abstractmethod
+    async def aclose_scope(self, scope_name: str) -> None:
+        """Asynchronously close all active scopes that contain the given scope name."""

--- a/src/diwire/container_scopes.py
+++ b/src/diwire/container_scopes.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from diwire.container_interface import IContainer
-from diwire.exceptions import DIWireScopeMismatchError
+from diwire.exceptions import DIWireInitialScopeCloseError, DIWireScopeMismatchError
 from diwire.service_key import ServiceKey
 from diwire.types import Factory, Lifetime
 
@@ -199,6 +199,8 @@ class ScopedContainer(IContainer):
         """Close the scope synchronously."""
         if self._exited:
             return
+        if self is self._container._initial_scope and not self._container._closing:  # noqa: SLF001
+            raise DIWireInitialScopeCloseError(self._container._initial_scope_name)  # noqa: SLF001
         with contextlib.suppress(ValueError, RuntimeError):
             _current_scope.reset(self._token)
         self._container._clear_scope(self._scope_id)  # noqa: SLF001
@@ -209,6 +211,8 @@ class ScopedContainer(IContainer):
         """Close the scope asynchronously."""
         if self._exited:
             return
+        if self is self._container._initial_scope and not self._container._closing:  # noqa: SLF001
+            raise DIWireInitialScopeCloseError(self._container._initial_scope_name)  # noqa: SLF001
         with contextlib.suppress(ValueError, RuntimeError):
             _current_scope.reset(self._token)
         await self._container._aclear_scope(self._scope_id)  # noqa: SLF001

--- a/src/diwire/exceptions.py
+++ b/src/diwire/exceptions.py
@@ -298,3 +298,13 @@ class DIWireContainerClosedError(DIWireError):
 
     def __init__(self) -> None:
         super().__init__("Cannot perform operation on a closed container.")
+
+
+class DIWireInvalidScopeNameError(DIWireError):
+    """Scope name is empty or blank."""
+
+    def __init__(self, scope_name: str) -> None:
+        self.scope_name = scope_name
+        super().__init__(
+            f"initial_scope must be a non-empty scope name, got {scope_name!r}."
+        )

--- a/src/diwire/exceptions.py
+++ b/src/diwire/exceptions.py
@@ -201,6 +201,16 @@ class DIWireContainerNotSetError(DIWireError):
         )
 
 
+class DIWireInitialScopeCloseError(DIWireError):
+    """Initial container scope cannot be closed explicitly."""
+
+    def __init__(self, scope_name: str) -> None:
+        super().__init__(
+            f"Initial scope '{scope_name}' cannot be closed explicitly. "
+            "Use container.close() or container.aclose() to close the container.",
+        )
+
+
 class DIWireDependencyExtractionError(DIWireError):
     """Failed to extract dependencies from a type."""
 

--- a/src/diwire/exceptions.py
+++ b/src/diwire/exceptions.py
@@ -305,6 +305,4 @@ class DIWireInvalidScopeNameError(DIWireError):
 
     def __init__(self, scope_name: str) -> None:
         self.scope_name = scope_name
-        super().__init__(
-            f"initial_scope must be a non-empty scope name, got {scope_name!r}."
-        )
+        super().__init__(f"initial_scope must be a non-empty scope name, got {scope_name!r}.")

--- a/src/diwire/integrations/fastapi.py
+++ b/src/diwire/integrations/fastapi.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - exercised in optional i
     raise ModuleNotFoundError(message) from exc
 
 if TYPE_CHECKING:
-    from diwire.container import Container
+    from diwire.container_interface import IContainer
 
 _DEFAULT_SCOPE = "request"
 _DIWIRE_WRAPPED_ATTR = "__diwire_wrapped__"
@@ -139,12 +139,12 @@ class DIWireRoute(APIRoute):
 
 def setup_diwire(
     app: FastAPI,
-    container: Container | None = None,
+    container: IContainer | None = None,
     *,
     scope: str | None = _DEFAULT_SCOPE,
-) -> Token[Container | None] | None:
+) -> Token[IContainer | None] | None:
     """Configure FastAPI to auto-wrap routes for diwire Injected parameters."""
-    token: Token[Container | None] | None = None
+    token: Token[IContainer | None] | None = None
     if container is not None:
         token = container_context.set_current(container)
         app.state.diwire_container = container

--- a/src/diwire/types.py
+++ b/src/diwire/types.py
@@ -20,6 +20,20 @@ class Lifetime(str, Enum):
     """Instance is shared within a scope, different instances across scopes."""
 
 
+class Scope(str, Enum):
+    """Predefined scope names for convenience.
+
+    Scope parameters accept any string; this enum only provides common defaults.
+    """
+
+    APP = "app"
+    """Application-wide scope (one per container or app lifetime)."""
+    SESSION = "session"
+    """Connection/session scope (e.g., websocket or user session)."""
+    REQUEST = "request"
+    """Request/job scope (one per request or unit of work)."""
+
+
 class FactoryClassProtocol:
     """Protocol for factory classes that create instances of a specific type."""
 

--- a/tests/unit/internal/test_circular_dependencies.py
+++ b/tests/unit/internal/test_circular_dependencies.py
@@ -236,7 +236,9 @@ class TestScopedCircularDependencies:
             lifetime=Lifetime.SCOPED,
         )
 
-        assert _current_scope.get() is None
+        scope = _current_scope.get()
+        assert scope is not None
+        assert scope.contains_scope("app")
 
         try:
             with container.enter_scope("request"):
@@ -245,7 +247,9 @@ class TestScopedCircularDependencies:
             pass
 
         # Scope context should be cleaned up after exception
-        assert _current_scope.get() is None
+        scope = _current_scope.get()
+        assert scope is not None
+        assert scope.contains_scope("app")
 
 
 # Module-level classes for async circular dependency tests
@@ -311,7 +315,9 @@ class TestAsyncCircularDependencies:
             lifetime=Lifetime.SCOPED,
         )
 
-        assert _current_scope.get() is None
+        scope = _current_scope.get()
+        assert scope is not None
+        assert scope.contains_scope("app")
 
         try:
             async with container.enter_scope("request"):
@@ -320,7 +326,9 @@ class TestAsyncCircularDependencies:
             pass
 
         # Scope context should be cleaned up
-        assert _current_scope.get() is None
+        scope = _current_scope.get()
+        assert scope is not None
+        assert scope.contains_scope("app")
 
     async def test_circular_dependency_async_non_compiled(self) -> None:
         """Circular dependency detected in aresolve without compilation.

--- a/tests/unit/internal/test_container.py
+++ b/tests/unit/internal/test_container.py
@@ -38,7 +38,7 @@ from diwire.exceptions import (
 )
 from diwire.registry import Registration
 from diwire.service_key import Component, ServiceKey
-from diwire.types import Injected, Lifetime
+from diwire.types import Injected, Lifetime, Scope
 
 
 # Module-level classes for circular dependency tests
@@ -716,7 +716,7 @@ class TestCompilationEdgeCases:
                 self.a = a
 
         container.register(ServiceA, lifetime=Lifetime.TRANSIENT)
-        container.register(ServiceB, scope="request", lifetime=Lifetime.SCOPED)
+        container.register(ServiceB, scope=Scope.REQUEST, lifetime=Lifetime.SCOPED)
 
         container.compile()
 
@@ -1052,7 +1052,7 @@ class TestAsyncResolutionEdgeCases:
             return b
 
         # resolve should work without crashing on nested scope detection
-        injected = container.resolve(handler, scope="request")
+        injected = container.resolve(handler, scope=Scope.REQUEST)
 
         # Verify it's a ScopedInjected (scope was detected from ServiceB registration)
         assert isinstance(injected, _ScopedInjectedFunction)

--- a/tests/unit/internal/test_container.py
+++ b/tests/unit/internal/test_container.py
@@ -34,6 +34,7 @@ from diwire.exceptions import (
     DIWireGeneratorFactoryDidNotYieldError,
     DIWireGeneratorFactoryUnsupportedLifetimeError,
     DIWireIgnoredServiceError,
+    DIWireInvalidScopeNameError,
     DIWireMissingDependenciesError,
     DIWireScopeMismatchError,
     DIWireServiceNotRegisteredError,
@@ -76,7 +77,7 @@ class _ServiceWithIgnoredType:
 
 
 def test_initial_scope_requires_name() -> None:
-    with pytest.raises(ValueError, match="initial_scope must be a non-empty scope name"):
+    with pytest.raises(DIWireInvalidScopeNameError):
         Container(initial_scope="   ")
 
 

--- a/tests/unit/internal/test_scopes.py
+++ b/tests/unit/internal/test_scopes.py
@@ -313,7 +313,7 @@ class TestScopeValidation:
         assert error.current_scope is not None
         assert "/wrong/" in error.current_scope
 
-    def test_autoregister_raises_error_when_scoped_registration_exists(self) -> None:
+    def test_autoregister_succeeds_when_scoped_registration_exists_in_app_scope(self) -> None:
         """Auto-registration succeeds when resolving within the app scope."""
         container = Container(autoregister=True)
         container.register(Session, scope="app", lifetime=Lifetime.SCOPED)

--- a/tests/unit/internal/test_scopes.py
+++ b/tests/unit/internal/test_scopes.py
@@ -42,7 +42,7 @@ def _assert_app_scope_active() -> _ScopeId:
 def _thread_with_empty_context(*, target: Any, args: tuple[Any, ...]) -> threading.Thread:
     """Create a thread with an empty ContextVar context when supported."""
     try:
-        return threading.Thread(target=target, args=args, context=Context())
+        return threading.Thread(target=target, args=args, context=Context())  # type: ignore[call-arg]
     except TypeError:
         return threading.Thread(target=target, args=args)
 
@@ -1032,9 +1032,7 @@ class TestScopeContextVariableIsolation:
             except Exception as e:
                 errors.append(e)
 
-        threads = [
-            _thread_with_empty_context(target=worker, args=(f"t{i}",)) for i in range(3)
-        ]
+        threads = [_thread_with_empty_context(target=worker, args=(f"t{i}",)) for i in range(3)]
         for t in threads:
             t.start()
         for t in threads:

--- a/tests/unit/internal/test_scopes.py
+++ b/tests/unit/internal/test_scopes.py
@@ -16,6 +16,7 @@ from diwire.container_scopes import ScopedContainer, _current_scope, _ScopeId
 from diwire.exceptions import (
     DIWireAsyncCleanupWithoutEventLoopError,
     DIWireGeneratorFactoryWithoutScopeError,
+    DIWireInitialScopeCloseError,
     DIWireMissingDependenciesError,
     DIWireScopedWithoutScopeError,
     DIWireScopeMismatchError,
@@ -28,6 +29,13 @@ from diwire.types import Injected, Lifetime
 
 def _scope_key_has_name(scope_key: tuple[tuple[str | None, int], ...], name: str) -> bool:
     return any(segment_name == name for segment_name, _ in scope_key)
+
+
+def _assert_app_scope_active() -> _ScopeId:
+    scope = _current_scope.get()
+    assert scope is not None
+    assert scope.contains_scope("app")
+    return scope
 
 
 @dataclass
@@ -100,25 +108,31 @@ class TestLifetimeScoped:
 class TestStartScope:
     """Tests for container.enter_scope()."""
 
+    def test_initial_scope_active_by_default(self, container: Container) -> None:
+        """Container starts with an active app scope."""
+        scope = _assert_app_scope_active()
+        assert container._initial_scope._scope_id == scope
+
     def test_enter_scope_sets_current_scope(self, container: Container) -> None:
         """enter_scope sets the current scope context variable."""
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
         with container.enter_scope("test_scope"):
             scope = _current_scope.get()
             assert scope is not None
             assert scope.contains_scope("test_scope")
+            assert scope.contains_scope("app")
 
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
     def test_enter_scope_with_auto_generated_name(self, container: Container) -> None:
         """enter_scope generates unique ID if no name provided."""
         with container.enter_scope() as scoped:
             scope_id = _current_scope.get()
             assert scope_id is not None
-            # Should have segments with None name and integer ID
-            assert len(scope_id.segments) == 1
-            name, instance_id = scope_id.segments[0]
+            # Should have last segment with None name and integer ID
+            assert len(scope_id.segments) == 2
+            name, instance_id = scope_id.segments[-1]
             assert name is None
             assert isinstance(instance_id, int)
 
@@ -152,12 +166,14 @@ class TestScopedContainer:
         with container.enter_scope("parent") as parent:
             parent_scope = _current_scope.get()
             assert parent_scope is not None
+            assert parent_scope.contains_scope("app")
             assert parent_scope.contains_scope("parent")
 
             with parent.enter_scope("child") as child:
                 child_scope = _current_scope.get()
                 assert child_scope is not None
                 # Child scope should contain parent scope and "child" segment
+                assert child_scope.contains_scope("app")
                 assert child_scope.contains_scope("parent")
                 assert child_scope.contains_scope("child")
                 # Child should have more segments than parent
@@ -172,10 +188,11 @@ class TestScopedContainer:
                 scope = _current_scope.get()
                 assert scope is not None
                 # Check hierarchy: segments contain a, b, c
+                assert scope.contains_scope("app")
                 assert scope.contains_scope("a")
                 assert scope.contains_scope("b")
                 assert scope.contains_scope("c")
-                assert len(scope.segments) == 3
+                assert len(scope.segments) == 4
 
 
 class TestScopedInjected:
@@ -259,7 +276,7 @@ class TestScopeValidation:
             container.resolve(Session)
 
     def test_scoped_service_not_found_without_scope(self) -> None:
-        """Resolving scoped service with no active scope raises DIWireServiceNotRegisteredError."""
+        """Resolving scoped service outside its scope raises DIWireServiceNotRegisteredError."""
         container = Container(autoregister=False)
         container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
 
@@ -285,30 +302,26 @@ class TestScopeValidation:
         error = exc_info.value
         assert error.registered_scope == "request"
         assert error.current_scope is not None
-        assert error.current_scope.startswith("wrong/")
+        assert "/wrong/" in error.current_scope
 
     def test_autoregister_raises_error_when_scoped_registration_exists(self) -> None:
-        """Auto-registration raises DIWireScopeMismatchError when a scoped registration exists."""
+        """Auto-registration succeeds when resolving within the app scope."""
         container = Container(autoregister=True)
         container.register(Session, scope="app", lifetime=Lifetime.SCOPED)
 
-        with pytest.raises(DIWireScopeMismatchError) as exc_info:
-            container.resolve(Session)
-
-        error = exc_info.value
-        assert error.registered_scope == "app"
-        assert error.current_scope is None
+        result = container.resolve(Session)
+        assert isinstance(result, Session)
 
     def test_autoregister_raises_error_in_wrong_scope(self) -> None:
         """Auto-registration raises DIWireScopeMismatchError when resolved in wrong scope."""
         container = Container(autoregister=True)
-        container.register(Session, scope="app", lifetime=Lifetime.SCOPED)
+        container.register(Session, scope="request", lifetime=Lifetime.SCOPED)
 
         with pytest.raises(DIWireScopeMismatchError) as exc_info, container.enter_scope("other"):
             container.resolve(Session)
 
         error = exc_info.value
-        assert error.registered_scope == "app"
+        assert error.registered_scope == "request"
         assert error.current_scope is not None
 
     def test_autoregister_still_works_for_unregistered_types(self) -> None:
@@ -703,7 +716,7 @@ class TestScopeCleanup:
             pass
 
         assert len(container._scope_caches) == 0
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
 
 class TestCaptiveDependency:
@@ -1401,8 +1414,12 @@ class TestFactoryEdgeCasesWithScopes:
 
         container.register(Session, factory=session_factory, lifetime=Lifetime.TRANSIENT)
 
-        with pytest.raises(DIWireGeneratorFactoryWithoutScopeError):
-            container.resolve(Session)
+        token = _current_scope.set(None)
+        try:
+            with pytest.raises(DIWireGeneratorFactoryWithoutScopeError):
+                container.resolve(Session)
+        finally:
+            _current_scope.reset(token)
 
     def test_generator_factories_close_in_nested_scopes(self, container: Container) -> None:
         """Nested scopes close generator factories in the right order."""
@@ -1475,7 +1492,7 @@ class TestScopeErrorRecovery:
 
     def test_exception_in_scope_exit_still_resets_context(self, container: Container) -> None:
         """Exception during scope exit: context still reset."""
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
         # We can't easily make clear_scope raise without modifying the container
         # So we test that normal exception handling still cleans up context
@@ -1488,7 +1505,7 @@ class TestScopeErrorRecovery:
         except RuntimeError:
             pass
 
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
     def test_resolve_from_manually_cleared_scope(self, container: Container) -> None:
         """Manual clear_scope then resolve: creates new instance (cache cleared)."""
@@ -1521,8 +1538,8 @@ class TestScopeErrorRecovery:
         # Manually calling clear_scope again should be idempotent (no error)
         container._clear_scope(scope_id)
 
-        # Still no error and scope context is None
-        assert _current_scope.get() is None
+        # Still no error and scope context is app
+        _assert_app_scope_active()
 
     def test_close_sync_continues_when_reset_fails(self, container: Container) -> None:
         """_close_sync completes cleanup even if ContextVar reset fails."""
@@ -2612,16 +2629,17 @@ class TestImperativeScopeManagement:
 
     def test_enter_scope_activates_immediately(self, container: Container) -> None:
         """enter_scope() activates the scope immediately."""
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
         scope = container.enter_scope("test")
         # Scope should be active immediately
         current = _current_scope.get()
         assert current is not None
         assert current.contains_scope("test")
+        assert current.contains_scope("app")
 
         scope.close()
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
     def test_imperative_scope_sync_resolve(self, container: Container) -> None:
         """Imperative scope works with sync resolve."""
@@ -2658,7 +2676,7 @@ class TestImperativeScopeManagement:
             assert _current_scope.get() is not None
 
         # Context manager exit should close the scope
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
     def test_nested_imperative_scopes(self, container: Container) -> None:
         """Nested imperative scopes work correctly."""
@@ -2668,22 +2686,25 @@ class TestImperativeScopeManagement:
         parent_scope = container.enter_scope("parent")
         current = _current_scope.get()
         assert current is not None
+        assert current.contains_scope("app")
         assert current.contains_scope("parent")
 
         child_scope = container.enter_scope("child")
         current = _current_scope.get()
         assert current is not None
+        assert current.contains_scope("app")
         assert current.contains_scope("parent")
         assert current.contains_scope("child")
 
         child_scope.close()
         current = _current_scope.get()
         assert current is not None
+        assert current.contains_scope("app")
         assert current.contains_scope("parent")
         assert not current.contains_scope("child")
 
         parent_scope.close()
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
     def test_container_close_closes_all_scopes_lifo(self, container: Container) -> None:
         """container.close() closes all scopes in LIFO order."""
@@ -2811,6 +2832,32 @@ class TestImperativeScopeManagement:
         container.close()
         assert container._closed
 
+    def test_initial_scope_cannot_close_directly(self, container: Container) -> None:
+        """Initial scope cannot be closed explicitly."""
+        with pytest.raises(DIWireInitialScopeCloseError):
+            container._initial_scope.close()
+
+    def test_close_scope_on_initial_scope_raises(self, container: Container) -> None:
+        """close_scope('app') does not close the initial scope."""
+        with pytest.raises(DIWireInitialScopeCloseError):
+            container.close_scope("app")
+
+    def test_initial_scope_aclose_raises(self, container: Container) -> None:
+        """Initial scope cannot be closed explicitly (async)."""
+
+        async def run_test() -> None:
+            with pytest.raises(DIWireInitialScopeCloseError):
+                await container._initial_scope.aclose()
+
+        asyncio.run(run_test())
+
+    def test_container_close_closes_initial_scope(self, container: Container) -> None:
+        """container.close() closes the initial scope."""
+        initial_scope = container._initial_scope
+        container.close()
+        assert initial_scope._exited
+        assert initial_scope not in container._active_scopes
+
     def test_mixed_imperative_and_context_manager(self, container: Container) -> None:
         """Imperative and context manager usage can be mixed."""
         container.register(Session, scope="outer", lifetime=Lifetime.SCOPED)
@@ -2821,17 +2868,19 @@ class TestImperativeScopeManagement:
         with container.enter_scope("inner"):
             current = _current_scope.get()
             assert current is not None
+            assert current.contains_scope("app")
             assert current.contains_scope("outer")
             assert current.contains_scope("inner")
 
         # Inner scope is closed by context manager
         current = _current_scope.get()
         assert current is not None
+        assert current.contains_scope("app")
         assert current.contains_scope("outer")
         assert not current.contains_scope("inner")
 
         outer_scope.close()
-        assert _current_scope.get() is None
+        _assert_app_scope_active()
 
     def test_close_scope_closes_named_scope(self, container: Container) -> None:
         """close_scope() closes a scope by name."""
@@ -2850,19 +2899,16 @@ class TestImperativeScopeManagement:
         container.register(Service, scope="session", lifetime=Lifetime.SCOPED)
 
         # Create hierarchy: app -> session -> request
-        app_scope = container.enter_scope("app")
         session_scope = container.enter_scope("session")
         request_scope = container.enter_scope("request")
 
         # All scopes should be active
-        assert not app_scope._exited
         assert not session_scope._exited
         assert not request_scope._exited
 
         # Close "session" should close both "session" and "request" (child)
         container.close_scope("session")
 
-        assert not app_scope._exited  # app should still be open
         assert session_scope._exited  # session should be closed
         assert request_scope._exited  # type: ignore[unreachable]  # request (child) closed
 
@@ -2871,8 +2917,6 @@ class TestImperativeScopeManagement:
         assert current is not None
         assert current.contains_scope("app")
         assert not current.contains_scope("session")
-
-        app_scope.close()
 
     def test_close_scope_leaves_unrelated_scopes_open(self, container: Container) -> None:
         """close_scope() does not affect scopes without the specified name."""
@@ -2934,7 +2978,6 @@ class TestImperativeScopeManagement:
         )
 
         async def run_test() -> None:
-            app_scope = container.enter_scope("app")
             session_scope = container.enter_scope("session")
             await container.aresolve(Session)
             request_scope = container.enter_scope("request")
@@ -2945,11 +2988,8 @@ class TestImperativeScopeManagement:
 
             # Request (child) should be cleaned up before session (parent)
             assert cleanup_order == ["request", "session"]
-            assert not app_scope._exited
             assert session_scope._exited
             assert request_scope._exited
-
-            app_scope.close()
 
         asyncio.run(run_test())
 
@@ -3025,15 +3065,15 @@ class TestImperativeScopeManagement:
         from unittest.mock import patch
 
         scope = container.enter_scope("test")
-        assert len(container._active_scopes) == 1
+        assert len(container._active_scopes) == 2
 
         with patch.object(scope, "close", side_effect=RuntimeError("close failed")):
             with pytest.raises(RuntimeError, match="close failed"):
                 container.close()
 
         # Scope should remain in _active_scopes after failure
-        assert len(container._active_scopes) == 1
-        assert container._active_scopes[0] is scope
+        assert len(container._active_scopes) == 2
+        assert container._active_scopes[-1] is scope
 
         # Cleanup: properly close the scope to reset _current_scope
         scope.close()
@@ -3044,7 +3084,7 @@ class TestImperativeScopeManagement:
 
         async def run_test() -> None:
             scope = container.enter_scope("test")
-            assert len(container._active_scopes) == 1
+            assert len(container._active_scopes) == 2
 
             mock_aclose = AsyncMock(side_effect=RuntimeError("aclose failed"))
             with patch.object(scope, "aclose", mock_aclose):
@@ -3052,8 +3092,8 @@ class TestImperativeScopeManagement:
                     await container.aclose()
 
             # Scope should remain in _active_scopes after failure
-            assert len(container._active_scopes) == 1
-            assert container._active_scopes[0] is scope
+            assert len(container._active_scopes) == 2
+            assert container._active_scopes[-1] is scope
 
             # Cleanup: properly close the scope to reset _current_scope
             await scope.aclose()
@@ -3069,7 +3109,7 @@ class TestImperativeScopeManagement:
 
             # Mark container as closed without draining scopes
             container._closed = True
-            assert len(container._active_scopes) == 2
+            assert len(container._active_scopes) == 3
 
             # aclose() should still drain remaining scopes
             await container.aclose()
@@ -3121,7 +3161,7 @@ class TestImperativeScopeManagement:
     def test_close_pops_scope_when_unregister_skipped(self, container: Container) -> None:
         """close() pops scope when _unregister_active_scope doesn't remove it."""
         scope = container.enter_scope("test")
-        assert len(container._active_scopes) == 1
+        assert len(container._active_scopes) == 2
 
         # Override _close_sync to skip _unregister_active_scope
         # This simulates scenario where Container.close() needs to pop
@@ -3149,7 +3189,7 @@ class TestImperativeScopeManagement:
 
         async def run_test() -> None:
             scope = container.enter_scope("test")
-            assert len(container._active_scopes) == 1
+            assert len(container._active_scopes) == 2
 
             # Override _close_async to skip _unregister_active_scope
             async def aclose_without_unregister() -> None:

--- a/tests/unit/public/test_container_interface.py
+++ b/tests/unit/public/test_container_interface.py
@@ -1,0 +1,75 @@
+import pytest
+
+from diwire import Container, IContainer, Injected, container_context
+
+
+def test_container_is_icontainer() -> None:
+    container = Container()
+    assert isinstance(container, IContainer)
+    assert issubclass(Container, IContainer)
+
+
+def test_container_context_is_icontainer() -> None:
+    assert isinstance(container_context, IContainer)
+    assert issubclass(type(container_context), IContainer)
+
+
+def test_scoped_container_is_icontainer() -> None:
+    container = Container()
+    with container.enter_scope("request") as scope:
+        assert isinstance(scope, IContainer)
+        assert issubclass(type(scope), IContainer)
+
+
+def test_scoped_container_delegates_register_compile_and_resolve() -> None:
+    container = Container(autoregister=False)
+
+    class Service:
+        pass
+
+    service = Service()
+
+    def handler(dep: Injected[Service]) -> Service:
+        return dep
+
+    with container.enter_scope("request") as scope:
+        scope.register(Service, instance=service)
+        scope.compile()
+        assert scope.resolve(Service) is service
+
+        decorated = scope.resolve()(handler)
+        assert decorated() is service
+
+        scoped_handler = scope.resolve(handler, scope="request")
+        assert scoped_handler() is service
+
+
+def test_scoped_container_close_scope() -> None:
+    container = Container()
+    with container.enter_scope("request") as scope:
+        scope.close_scope("request")
+
+
+@pytest.mark.asyncio
+async def test_scoped_container_aresolve_with_scope() -> None:
+    container = Container(autoregister=False)
+
+    class Service:
+        pass
+
+    service = Service()
+    container.register(Service, instance=service)
+
+    async def handler(dep: Injected[Service]) -> Service:
+        return dep
+
+    with container.enter_scope("request") as scope:
+        scoped_handler = await scope.aresolve(handler, scope="request")
+        assert await scoped_handler() is service
+
+
+@pytest.mark.asyncio
+async def test_scoped_container_aclose_scope() -> None:
+    container = Container()
+    async with container.enter_scope("request") as scope:
+        await scope.aclose_scope("request")

--- a/tests/unit/public/test_ignored_types_registration.py
+++ b/tests/unit/public/test_ignored_types_registration.py
@@ -46,10 +46,33 @@ class TestPrimitiveTypesExplicitRegistration:
         result = container.resolve(Service)
         assert result.value == 42
 
+    def test_registered_int_scoped_is_resolved_sync(self, container: Container) -> None:
+        """Sync: scoped registered int should be injected in app scope."""
+        container.register(int, instance=42, scope="app", lifetime=Lifetime.SCOPED)
+
+        class Service:
+            def __init__(self, value: int) -> None:
+                self.value = value
+
+        result = container.resolve(Service)
+        assert result.value == 42
+
     @pytest.mark.asyncio
     async def test_registered_int_is_resolved_async(self, container: Container) -> None:
         """Async: registered int should be injected."""
         container.register(int, instance=42)
+
+        class Service:
+            def __init__(self, value: int) -> None:
+                self.value = value
+
+        result = await container.aresolve(Service)
+        assert result.value == 42
+
+    @pytest.mark.asyncio
+    async def test_registered_int_scoped_is_resolved_async(self, container: Container) -> None:
+        """Async: scoped registered int should be injected in app scope."""
+        container.register(int, instance=42, scope="app", lifetime=Lifetime.SCOPED)
 
         class Service:
             def __init__(self, value: int) -> None:

--- a/tests/unit/public/test_types.py
+++ b/tests/unit/public/test_types.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, cast, get_args, get_origin
 
 from diwire.exceptions import DIWireInjectedInstantiationError
 from diwire.service_key import Component
-from diwire.types import Injected, Lifetime, _InjectedMarker
+from diwire.types import Injected, Lifetime, Scope, _InjectedMarker
 
 
 class TestLifetime:
@@ -71,6 +71,32 @@ class TestInjected:
         assert args[0] is ServiceA
         assert any(isinstance(arg, Component) for arg in args[1:])
         assert any(isinstance(arg, _InjectedMarker) for arg in args[1:])
+
+
+class TestScope:
+    def test_scope_app_value(self) -> None:
+        """APP has value 'app'."""
+        assert Scope.APP.value == "app"
+
+    def test_scope_session_value(self) -> None:
+        """SESSION has value 'session'."""
+        assert Scope.SESSION.value == "session"
+
+    def test_scope_request_value(self) -> None:
+        """REQUEST has value 'request'."""
+        assert Scope.REQUEST.value == "request"
+
+    def test_scope_is_enum(self) -> None:
+        """Scope is an Enum."""
+        assert issubclass(Scope, Enum)
+
+    def test_scope_enum_members(self) -> None:
+        """Scope has exactly three members."""
+        members = list(Scope)
+        assert len(members) == 3
+        assert Scope.APP in members
+        assert Scope.SESSION in members
+        assert Scope.REQUEST in members
 
 
 class TestFactoryProtocol:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a Scope enum (APP, SESSION, REQUEST), a public container interface, and an implicit initial app scope. Generator factories without an explicit scope now attach to that initial app scope.
  * Adds explicit errors for invalid/empty initial scope names and for attempts to close the initial app scope.

* **Documentation**
  * Examples and guides updated to use Scope constants and clarify scope lifecycle and generator cleanup behavior.

* **Tests**
  * Test suite updated to validate new scope semantics and related error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->