### PR TITLE
docs: update documentation to use Scope enum for dependency injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ the current public API.
 
 ## Quick commands
 
-- Install deps (dev): `uv sync --dev`
+- Install deps (dev): `uv sync --group dev`
 - Format: `make format`
 - Lint (all): `make lint`
 - Test (all): `make test`
@@ -22,18 +22,16 @@ the current public API.
 - Ruff lint: `uv run ruff check .`
 - Ruff auto-fix (limited): `uv run ruff check --fix-only .`
 - Ruff format: `uv run ruff format .`
-- ty type checks: `uv run ty check .`
-- pyrefly checks: `uv run pyrefly check .`
 - mypy (strict): `uv run mypy .`
 
 ## Tests
 
-- Run all tests: `uv run pytest tests/`
+- Run all tests (coverage): `make test`
 - Run a single test file: `uv run pytest tests/unit/internal/test_container.py`
 - Run a single test: `uv run pytest tests/unit/internal/test_container.py::test_register`
 - Run tests with keyword filter: `uv run pytest -k "dependency" tests/`
 - Coverage (recommended for new work):
-  `uv run pytest --cov=diwire --cov-report=term-missing tests/`
+  `uv run pytest tests/ --benchmark-skip --cov=src/diwire --cov-report=term-missing`
 
 ## Repo structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 # Setup
 uv sync --group dev
+# Docs (optional)
+uv sync --group dev --group docs
 
 # Development workflow
 make format    # Format with ruff, auto-fix issues
-make lint      # Run all checks: ruff, ty, pyrefly, mypy (strict)
+make lint      # Run all checks: ruff, mypy (strict)
 make test      # Run tests with 100% coverage requirement
 
 # Single test execution
@@ -31,7 +33,7 @@ diwire is a type-driven dependency injection container with zero runtime depende
 - `container_context.py` - Global context proxy for lazy container resolution via ContextVar
 - `dependencies.py` - Type hint extraction with caching
 - `exceptions.py` - 15+ custom exception types with detailed error messages
-- `types.py` - `Lifetime` enum, `Injected` marker, `Factory` type alias
+- `types.py` - `Lifetime`/`Scope` enums, `Injected[T]` type wrapper, `Factory` type alias
 
 **Resolution flow**: Service request → check caches → get/auto-register → extract dependencies → resolve recursively → instantiate → cache by lifetime
 
@@ -69,6 +71,7 @@ Test layout:
 Main exports from `diwire`:
 - `Container` - DI container
 - `Lifetime` - TRANSIENT, SINGLETON, SCOPED
-- `Injected` - Mark function parameters for injection
+- `Scope` - APP, SESSION, REQUEST
+- `Injected` - Mark function parameters for injection (`Injected[T]`)
 - `Component` - Named component registration
 - `container_context` - Global context for lazy resolution

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Define your classes. Resolve the top-level one. diwire figures out the rest.
 
 ```python
 from dataclasses import dataclass
-from diwire import Container, Lifetime
+from diwire import Container, Lifetime, Scope
 
 
 @dataclass
@@ -63,7 +63,7 @@ Dependencies are resolved from type hints — no manual wiring required.
 
 ```python
 from dataclasses import dataclass
-from diwire import Container
+from diwire import Container, Scope
 
 
 @dataclass
@@ -97,7 +97,7 @@ Use `@container.register` as a decorator on classes, factory functions, and stat
 from dataclasses import dataclass
 from typing import Annotated, Protocol
 
-from diwire import Container, Lifetime, Component
+from diwire import Container, Lifetime, Scope, Component
 
 
 class IDatabase(Protocol):
@@ -150,7 +150,7 @@ Control how instances are created and shared.
 
 ```python
 from dataclasses import dataclass
-from diwire import Container, Lifetime
+from diwire import Container, Lifetime, Scope
 
 
 @dataclass
@@ -299,7 +299,7 @@ Mark parameters with `Injected[T]` to inject dependencies while keeping other pa
 ```python
 from dataclasses import dataclass
 
-from diwire import Container, Injected
+from diwire import Container, Injected, Scope
 
 
 @dataclass
@@ -331,7 +331,7 @@ Register a protocol or abstract base class and resolve it to a concrete implemen
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
-from diwire import Container, Lifetime
+from diwire import Container, Lifetime, Scope
 
 
 class Clock(Protocol):
@@ -358,7 +358,7 @@ Use `Component` to register multiple implementations of the same interface.
 ```python
 from dataclasses import dataclass
 from typing import Annotated, Protocol
-from diwire import Container, Component
+from diwire import Container, Scope, Component
 
 
 class Cache(Protocol):
@@ -396,7 +396,7 @@ are enforced at resolution time.
 ```python
 from dataclasses import dataclass
 from typing import Generic, TypeVar
-from diwire import Container
+from diwire import Container, Scope
 
 
 class Model:
@@ -441,7 +441,7 @@ print(container.resolve(ModelBox[Model]))  # => ModelBox(model=<Model ...>)
 ```python
 from dataclasses import dataclass
 
-from diwire import Container, Injected, container_context
+from diwire import Container, Injected, Scope, container_context
 
 
 @container_context.register()
@@ -468,7 +468,7 @@ lookups. The container auto-compiles on first resolve by default.
 
 ```python
 from dataclasses import dataclass
-from diwire import Container, Lifetime
+from diwire import Container, Lifetime, Scope
 
 
 @dataclass

--- a/docs/core/container-context.rst
+++ b/docs/core/container-context.rst
@@ -21,7 +21,6 @@ Basic usage
 .. code-block:: python
 
    from dataclasses import dataclass
-   from typing import Annotated
 
    from diwire import Container, Injected, Lifetime, container_context
 

--- a/docs/core/function-injection.rst
+++ b/docs/core/function-injection.rst
@@ -8,7 +8,7 @@ In addition to constructor injection, diwire can inject dependencies into functi
 
 The building blocks are:
 
-- :class:`diwire.Injected` - a marker used inside ``typing.Annotated``
+- :class:`diwire.Injected` - a type wrapper used as ``Injected[T]`` to mark injected parameters
 - :meth:`diwire.Container.resolve` - when given a function, returns an injected callable wrapper
 
 Basic injection with ``Injected[T]``
@@ -33,7 +33,6 @@ You can also use ``resolve()`` as a decorator:
 
 .. code-block:: python
 
-   from typing import Annotated
    from diwire import Container, Injected
 
    container = Container()

--- a/docs/core/scopes.rst
+++ b/docs/core/scopes.rst
@@ -61,7 +61,9 @@ You can also manage scopes imperatively:
 
 .. code-block:: python
 
-   scope = container.enter_scope("request")
+   from diwire import Scope
+
+   scope = container.enter_scope(Scope.REQUEST)
    try:
        ...
    finally:

--- a/docs/howto/testing/pytest.rst
+++ b/docs/howto/testing/pytest.rst
@@ -20,8 +20,6 @@ Then annotate parameters:
 
 .. code-block:: python
 
-   from typing import Annotated
-
    from diwire import Injected
 
 

--- a/src/diwire/container.py
+++ b/src/diwire/container.py
@@ -1026,12 +1026,12 @@ class Container(IContainer):
         """Start a new scope for resolving SCOPED dependencies.
 
         The scope is activated immediately upon creation, allowing imperative usage:
-            scope = container.enter_scope("request")
+            scope = container.enter_scope(Scope.REQUEST)
             # ... use the scope ...
             scope.close()  # or container.close() to close all scopes
 
         Context manager usage is also supported:
-            with container.enter_scope("request") as scope:
+            with container.enter_scope(Scope.REQUEST) as scope:
                 # ... use the scope ...
 
         Args:
@@ -1670,11 +1670,11 @@ class Container(IContainer):
             .. code-block:: python
 
                 # Direct usage:
-                injected = container.resolve(my_func, scope="request")
+                injected = container.resolve(my_func, scope=Scope.REQUEST)
 
 
                 # Decorator usage:
-                @container.resolve(scope="request")
+                @container.resolve(scope=Scope.REQUEST)
                 async def handler(service: Injected[Service]) -> dict: ...
 
         """
@@ -2113,7 +2113,7 @@ class Container(IContainer):
 
         Examples:
             # Direct usage:
-            injected = await container.aresolve(my_func, scope="request")
+            injected = await container.aresolve(my_func, scope=Scope.REQUEST)
 
         """
         self._check_not_closed()

--- a/src/diwire/container_context.py
+++ b/src/diwire/container_context.py
@@ -403,7 +403,10 @@ class _ContainerContextProxy(IContainer):
             .. code-block:: python
 
                 # Decorator usage (container looked up at call time):
-                @container_context.resolve(scope="request")
+                from diwire import Scope
+
+
+                @container_context.resolve(scope=Scope.REQUEST)
                 async def handler(service: Injected[Service]) -> dict: ...
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Scope enum (APP, SESSION, REQUEST) and switched parameter marker to Injected[T] for clearer, type-safe usage.

* **Documentation**
  * Updated examples and API docs to use Scope and Injected[T] syntax.
  * Streamlined developer docs and test commands (updated quick commands and test invocation examples).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->