### PR TITLE
 feat: add wireup benchmark baseline and support dataclass default_factory fallback in strict mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ benchmark-report: benchmark-json
 		--markdown benchmark-results/benchmark-table.md \
 		--json benchmark-results/benchmark-table.json \
 		--comment benchmark-results/pr-comment.md \
-		--libraries diwire,rodi,dishka
+		--libraries diwire,rodi,dishka,wireup
 
 benchmark-report-all: benchmark-json
 	uv run python -m tools.benchmark_reporting \
@@ -56,7 +56,7 @@ benchmark-report-all: benchmark-json
 		--markdown benchmark-results/benchmark-table-all.md \
 		--json benchmark-results/benchmark-table-all.json \
 		--comment benchmark-results/pr-comment-all.md \
-		--libraries diwire,rodi,dishka,punq
+		--libraries diwire,rodi,dishka,wireup,punq
 
 benchmark-json-resolve:
 	mkdir -p benchmark-results
@@ -73,4 +73,4 @@ benchmark-report-resolve: benchmark-json-resolve
 		--markdown benchmark-results/benchmark-table-resolve.md \
 		--json benchmark-results/benchmark-table-resolve.json \
 		--comment benchmark-results/pr-comment-resolve.md \
-		--libraries diwire,rodi,dishka,punq
+		--libraries diwire,rodi,dishka,wireup,punq

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ resolvers, and free-threaded Python (no-GIL) — all with zero runtime dependenc
 
 Benchmarks + methodology live in the docs: [Performance](https://docs.diwire.dev/howto/advanced/performance/).
 
-In this benchmark suite on CPython ``3.12.5`` (Apple M1 Pro, strict mode):
+In this benchmark suite on CPython ``3.14.2`` (Apple M1 Pro, strict mode):
 
-- Speedup over ``rodi`` ranges from **1.22×** to **2.19×**.
-- Speedup over ``dishka`` ranges from **1.81×** to **7.76×**.
-- Resolve-only comparisons (includes ``punq`` in non-scope scenarios): speedup ranges from **3.31×** to **268.84×**.
+- Speedup over ``rodi`` ranges from **1.28×** to **2.48×**.
+- Speedup over ``dishka`` ranges from **2.03×** to **7.62×**.
+- Speedup over ``wireup`` ranges from **1.06×** to **3.31×**.
+- Resolve-only comparisons (includes ``punq`` in non-scope scenarios): speedup over ``punq`` ranges from **2.47×** to **388.44×**.
+- Current benchmark totals: **10** full-suite scenarios and **4** resolve-only scenarios.
 
 Results vary by environment, Python version, and hardware. Re-run ``make benchmark-report`` and
 ``make benchmark-report-resolve`` on your target runtime before drawing final conclusions for production workloads.

--- a/docs/howto/advanced/performance.rst
+++ b/docs/howto/advanced/performance.rst
@@ -33,14 +33,15 @@ Resolve-only comparison table (includes ``punq``):
 
 Benchmarked library versions:
 
-- diwire: editable checkout at commit ``48a6519f831372da5d7d5ab98345ba69778dc3f0`` (branch ``v1``, dirty working tree)
-- dishka: ``1.7.2``
+- diwire: editable checkout at commit ``7d467211568d7955a92f929e613450521cc1b114`` (branch ``comparison-table``, dirty working tree)
+- dishka: ``1.8.0``
 - punq: ``0.7.0``
 - rodi: ``2.0.8``
+- wireup: ``2.7.0``
 
 Environment (from ``benchmark-results/raw-benchmark.json``):
 
-- Python: CPython ``3.12.5``
+- Python: CPython ``3.14.2``
 - OS/CPU: Darwin arm64 (Apple M1 Pro)
 
 Methodology details for diwire in these benchmarks:
@@ -50,8 +51,8 @@ Methodology details for diwire in these benchmarks:
 - All benchmark registrations are explicit.
 - ``container.compile()`` is called once after registration setup and before timed loops to measure compiled steady-state entrypoints.
 
-Results (diwire vs rodi and dishka)
------------------------------------
+Results (diwire vs rodi, dishka, and wireup)
+--------------------------------------------
 
 Source of truth: ``benchmark-results/benchmark-table.json`` (rendered to ``benchmark-results/benchmark-table.md``).
 
@@ -62,74 +63,97 @@ Source of truth: ``benchmark-results/benchmark-table.json`` (rendered to ``bench
      - diwire (ops/s)
      - rodi (ops/s)
      - dishka (ops/s)
+     - wireup (ops/s)
      - Speedup (diwire/rodi)
      - Speedup (diwire/dishka)
+     - Speedup (diwire/wireup)
    * - enter_close_scope_no_resolve
-     - 4890376
-     - 3404710
-     - 1000090
+     - 6518660
+     - 4524061
+     - 860796
+     - 1971905
      - 1.44×
-     - 4.89×
+     - 7.57×
+     - 3.31×
    * - enter_close_scope_resolve_100_instance
-     - 83981
-     - 54992
-     - 13274
-     - 1.53×
-     - 6.33×
+     - 87070
+     - 58303
+     - 11494
+     - 67470
+     - 1.49×
+     - 7.57×
+     - 1.29×
    * - enter_close_scope_resolve_once
-     - 3134287
-     - 2094023
-     - 403971
-     - 1.50×
-     - 7.76×
+     - 3676678
+     - 2510567
+     - 482201
+     - 1481135
+     - 1.46×
+     - 7.62×
+     - 2.48×
    * - enter_close_scope_resolve_scoped_100
-     - 95893
-     - 78328
-     - 40845
-     - 1.22×
-     - 2.35×
+     - 93662
+     - 72891
+     - 38950
+     - 67401
+     - 1.28×
+     - 2.40×
+     - 1.39×
    * - resolve_deep_transient_chain
-     - 1357614
-     - 710215
-     - 653016
-     - 1.91×
-     - 2.08×
+     - 1816309
+     - 733845
+     - 754110
+     - 915855
+     - 2.48×
+     - 2.41×
+     - 1.98×
    * - resolve_mixed_lifetimes
-     - 1590693
-     - 1001925
-     - 421357
-     - 1.59×
-     - 3.78×
+     - 2271693
+     - 1107436
+     - 382173
+     - 898465
+     - 2.05×
+     - 5.94×
+     - 2.53×
    * - resolve_scoped
-     - 2039077
-     - 1486316
-     - 692814
-     - 1.37×
-     - 2.94×
+     - 2840744
+     - 1840370
+     - 591232
+     - 1351828
+     - 1.54×
+     - 4.80×
+     - 2.10×
    * - resolve_singleton
-     - 6539556
-     - 3260371
-     - 3606062
-     - 2.01×
-     - 1.81×
+     - 6978367
+     - 3543417
+     - 3441938
+     - 5128950
+     - 1.97×
+     - 2.03×
+     - 1.36×
    * - resolve_transient
-     - 5232422
-     - 2514313
-     - 2390968
-     - 2.08×
+     - 5397358
+     - 2682653
+     - 2464092
+     - 5083800
+     - 2.01×
      - 2.19×
+     - 1.06×
    * - resolve_wide_transient_graph
-     - 1665818
-     - 761640
-     - 679907
-     - 2.19×
-     - 2.45×
+     - 1849443
+     - 832000
+     - 782193
+     - 1285315
+     - 2.22×
+     - 2.36×
+     - 1.44×
 
 Summary (computed from the table above):
 
 - diwire is the top ops/s implementation in all benchmark scenarios in this strict-mode run.
-- Speedup over rodi ranges from **1.22×** to **2.19×**.
-- Speedup over dishka ranges from **1.81×** to **7.76×**.
+- Speedup over rodi ranges from **1.28×** to **2.48×**.
+- Speedup over dishka ranges from **2.03×** to **7.62×**.
+- Speedup over wireup ranges from **1.06×** to **3.31×**.
 
 Results vary by environment, Python version, and hardware. Re-run ``make benchmark-report`` on your target runtime
 before drawing final conclusions for production workloads.
@@ -149,43 +173,54 @@ Source of truth: ``benchmark-results/benchmark-table-resolve.json`` (rendered to
      - diwire (ops/s)
      - rodi (ops/s)
      - dishka (ops/s)
+     - wireup (ops/s)
      - punq (ops/s)
      - Speedup (diwire/rodi)
      - Speedup (diwire/dishka)
+     - Speedup (diwire/wireup)
      - Speedup (diwire/punq)
    * - resolve_deep_transient_chain
-     - 1304305
-     - 711307
-     - 639173
-     - 12450
-     - 1.83×
-     - 2.04×
-     - 104.76×
+     - 1764124
+     - 722462
+     - 736488
+     - 892946
+     - 10730
+     - 2.44×
+     - 2.40×
+     - 1.98×
+     - 164.40×
    * - resolve_singleton
-     - 6636706
-     - 3212902
-     - 3593792
-     - 2004608
-     - 2.07×
-     - 1.85×
-     - 3.31×
+     - 5861293
+     - 3441404
+     - 3406823
+     - 5022682
+     - 2368448
+     - 1.70×
+     - 1.72×
+     - 1.17×
+     - 2.47×
    * - resolve_transient
-     - 5290168
-     - 2492831
-     - 2415740
-     - 34197
-     - 2.12×
-     - 2.19×
-     - 154.70×
+     - 5231024
+     - 2709566
+     - 2450974
+     - 4974766
+     - 23905
+     - 1.93×
+     - 2.13×
+     - 1.05×
+     - 218.82×
    * - resolve_wide_transient_graph
-     - 1659712
-     - 781090
-     - 662153
-     - 6174
-     - 2.12×
-     - 2.51×
-     - 268.84×
+     - 1911370
+     - 827975
+     - 767232
+     - 1278817
+     - 4921
+     - 2.31×
+     - 2.49×
+     - 1.49×
+     - 388.44×
 
 Summary (computed from the table above):
 
-- Speedup over punq ranges from **3.31×** to **268.84×** in these resolve-only scenarios.
+- Speedup over wireup ranges from **1.05×** to **1.98×** in these resolve-only scenarios.
+- Speedup over punq ranges from **2.47×** to **388.44×** in these resolve-only scenarios.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2975,6 +2975,7 @@ Files:
 - [03_attrs.py](#ex-12-supported-frameworks--03-attrs-py)
 - [04_pydantic.py](#ex-12-supported-frameworks--04-pydantic-py)
 - [05_msgspec.py](#ex-12-supported-frameworks--05-msgspec-py)
+- [06_dataclass_default_factory.py](#ex-12-supported-frameworks--06-dataclass-default-factory-py)
 
 <a id="ex-12-supported-frameworks--01-dataclass-py"></a>
 ### [01_dataclass.py](ex_12_supported_frameworks/01_dataclass.py)
@@ -3152,6 +3153,78 @@ def main() -> None:
     print(
         f"msgspec_ok={container.resolve(Consumer).dependency is dependency}",
     )  # => msgspec_ok=True
+
+
+if __name__ == "__main__":
+    main()
+```
+
+<a id="ex-12-supported-frameworks--06-dataclass-default-factory-py"></a>
+### [06_dataclass_default_factory.py](ex_12_supported_frameworks/06_dataclass_default_factory.py)
+
+Focused example: dataclass ``default_factory`` fallback in strict mode.
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from diwire import Container, DependencyRegistrationPolicy, Lifetime, MissingPolicy
+from diwire.exceptions import DIWireDependencyNotRegisteredError
+
+
+class ApiClient:
+    pass
+
+
+@dataclass(slots=True)
+class ServiceWithFactoryDefault:
+    client: ApiClient = field(default_factory=ApiClient)
+
+
+_DEFAULT_CLIENT = ApiClient()
+
+
+@dataclass(slots=True)
+class ServiceWithValueDefault:
+    client: ApiClient = _DEFAULT_CLIENT
+
+
+def strict_container() -> Container:
+    return Container(
+        missing_policy=MissingPolicy.ERROR,
+        dependency_registration_policy=DependencyRegistrationPolicy.IGNORE,
+    )
+
+
+def main() -> None:
+    container = strict_container()
+    container.add(
+        ServiceWithFactoryDefault,
+        provides=ServiceWithFactoryDefault,
+        lifetime=Lifetime.TRANSIENT,
+    )
+
+    resolved_from_factory = container.resolve(ServiceWithFactoryDefault)
+    print(
+        f"factory_default_used={isinstance(resolved_from_factory.client, ApiClient)}",
+    )  # => factory_default_used=True
+
+    registered_client = ApiClient()
+    container.add_instance(registered_client, provides=ApiClient)
+    resolved_with_registration = container.resolve(ServiceWithFactoryDefault)
+    print(
+        f"registered_overrides_factory={resolved_with_registration.client is registered_client}",
+    )  # => registered_overrides_factory=True
+
+    strict_value_default = strict_container()
+    strict_value_default.add(ServiceWithValueDefault, provides=ServiceWithValueDefault)
+    try:
+        strict_value_default.resolve(ServiceWithValueDefault)
+    except DIWireDependencyNotRegisteredError as error:
+        print(
+            f"value_default_stays_strict={type(error).__name__}",
+        )  # => value_default_stays_strict=DIWireDependencyNotRegisteredError
 
 
 if __name__ == "__main__":

--- a/examples/ex_12_supported_frameworks/06_dataclass_default_factory.py
+++ b/examples/ex_12_supported_frameworks/06_dataclass_default_factory.py
@@ -1,0 +1,66 @@
+"""Focused example: dataclass ``default_factory`` fallback in strict mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from diwire import Container, DependencyRegistrationPolicy, Lifetime, MissingPolicy
+from diwire.exceptions import DIWireDependencyNotRegisteredError
+
+
+class ApiClient:
+    pass
+
+
+@dataclass(slots=True)
+class ServiceWithFactoryDefault:
+    client: ApiClient = field(default_factory=ApiClient)
+
+
+_DEFAULT_CLIENT = ApiClient()
+
+
+@dataclass(slots=True)
+class ServiceWithValueDefault:
+    client: ApiClient = _DEFAULT_CLIENT
+
+
+def strict_container() -> Container:
+    return Container(
+        missing_policy=MissingPolicy.ERROR,
+        dependency_registration_policy=DependencyRegistrationPolicy.IGNORE,
+    )
+
+
+def main() -> None:
+    container = strict_container()
+    container.add(
+        ServiceWithFactoryDefault,
+        provides=ServiceWithFactoryDefault,
+        lifetime=Lifetime.TRANSIENT,
+    )
+
+    resolved_from_factory = container.resolve(ServiceWithFactoryDefault)
+    print(
+        f"factory_default_used={isinstance(resolved_from_factory.client, ApiClient)}",
+    )  # => factory_default_used=True
+
+    registered_client = ApiClient()
+    container.add_instance(registered_client, provides=ApiClient)
+    resolved_with_registration = container.resolve(ServiceWithFactoryDefault)
+    print(
+        f"registered_overrides_factory={resolved_with_registration.client is registered_client}",
+    )  # => registered_overrides_factory=True
+
+    strict_value_default = strict_container()
+    strict_value_default.add(ServiceWithValueDefault, provides=ServiceWithValueDefault)
+    try:
+        strict_value_default.resolve(ServiceWithValueDefault)
+    except DIWireDependencyNotRegisteredError as error:
+        print(
+            f"value_default_stays_strict={type(error).__name__}",
+        )  # => value_default_stays_strict=DIWireDependencyNotRegisteredError
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "ty>=0.0.15",
     "pyrefly>=0.51.2",
     "typing-extensions>=4.15.0",
+    "wireup>=2.7.0",
 ]
 
 docs = [

--- a/tests/benchmarks/test_enter_close_scope_no_resolve.py
+++ b/tests/benchmarks/test_enter_close_scope_no_resolve.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 from typing import Any
 
 import rodi
+from wireup import injectable
 
 from tests.benchmarks.dishka_helpers import DishkaBenchmarkScope, make_dishka_benchmark_container
 from tests.benchmarks.helpers import make_diwire_benchmark_container
+from tests.benchmarks.wireup_helpers import make_wireup_benchmark_container
 
 _BENCHMARK_ITERATIONS = 100_000
 _BENCHMARK_WARMUP_ROUNDS = 3
 _BENCHMARK_ROUNDS = 5
+
+
+@injectable(lifetime="singleton")
+class _SingletonValue:
+    def __init__(self) -> None:
+        self.value = 42
 
 
 def test_benchmark_diwire_enter_close_scope_no_resolve(benchmark: Any) -> None:
@@ -64,6 +72,24 @@ def test_benchmark_dishka_enter_close_scope_no_resolve(benchmark: Any) -> None:
 
     benchmark.pedantic(
         target=bench_dishka_enter_close_scope_no_resolve,
+        warmup_rounds=_BENCHMARK_WARMUP_ROUNDS,
+        rounds=_BENCHMARK_ROUNDS,
+        iterations=_BENCHMARK_ITERATIONS,
+    )
+
+
+def test_benchmark_wireup_enter_close_scope_no_resolve(benchmark: Any) -> None:
+    container = make_wireup_benchmark_container(_SingletonValue)
+    assert container.get(_SingletonValue).value == 42
+    with container.enter_scope() as scope:
+        assert scope.get(_SingletonValue).value == 42
+
+    def bench_wireup_enter_close_scope_no_resolve() -> None:
+        with container.enter_scope():
+            pass
+
+    benchmark.pedantic(
+        target=bench_wireup_enter_close_scope_no_resolve,
         warmup_rounds=_BENCHMARK_WARMUP_ROUNDS,
         rounds=_BENCHMARK_ROUNDS,
         iterations=_BENCHMARK_ITERATIONS,

--- a/tests/benchmarks/test_enter_close_scope_resolve_100_instance.py
+++ b/tests/benchmarks/test_enter_close_scope_resolve_100_instance.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 from typing import Any
 
 import rodi
+from wireup import injectable
 
 from tests.benchmarks.dishka_helpers import DishkaBenchmarkScope, make_dishka_benchmark_container
 from tests.benchmarks.helpers import make_diwire_benchmark_container
+from tests.benchmarks.wireup_helpers import make_wireup_benchmark_container
 
 _BENCHMARK_ITERATIONS = 1_000
 _BENCHMARK_WARMUP_ROUNDS = 3
 _BENCHMARK_ROUNDS = 5
+
+
+@injectable(lifetime="singleton")
+class _SingletonValue:
+    def __init__(self) -> None:
+        self.value = 42
 
 
 def test_benchmark_diwire_enter_close_scope_resolve_100(benchmark: Any) -> None:
@@ -70,6 +78,26 @@ def test_benchmark_dishka_enter_close_scope_resolve_100(benchmark: Any) -> None:
 
     benchmark.pedantic(
         target=bench_dishka_enter_close_scope_resolve_100,
+        warmup_rounds=_BENCHMARK_WARMUP_ROUNDS,
+        rounds=_BENCHMARK_ROUNDS,
+        iterations=_BENCHMARK_ITERATIONS,
+    )
+
+
+def test_benchmark_wireup_enter_close_scope_resolve_100(benchmark: Any) -> None:
+    container = make_wireup_benchmark_container(_SingletonValue)
+    assert container.get(_SingletonValue).value == 42
+    with container.enter_scope() as scope:
+        values = [scope.get(_SingletonValue).value for _ in range(3)]
+    assert values == [42, 42, 42]
+
+    def bench_wireup_enter_close_scope_resolve_100() -> None:
+        with container.enter_scope() as scope:
+            for _ in range(100):
+                _value = scope.get(_SingletonValue)
+
+    benchmark.pedantic(
+        target=bench_wireup_enter_close_scope_resolve_100,
         warmup_rounds=_BENCHMARK_WARMUP_ROUNDS,
         rounds=_BENCHMARK_ROUNDS,
         iterations=_BENCHMARK_ITERATIONS,

--- a/tests/benchmarks/test_enter_close_scope_resolve_once.py
+++ b/tests/benchmarks/test_enter_close_scope_resolve_once.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 from typing import Any
 
 import rodi
+from wireup import injectable
 
 from tests.benchmarks.dishka_helpers import DishkaBenchmarkScope, make_dishka_benchmark_container
 from tests.benchmarks.helpers import make_diwire_benchmark_container
+from tests.benchmarks.wireup_helpers import make_wireup_benchmark_container
 
 _BENCHMARK_ITERATIONS = 100_000
 _BENCHMARK_WARMUP_ROUNDS = 3
 _BENCHMARK_ROUNDS = 5
+
+
+@injectable(lifetime="singleton")
+class _SingletonValue:
+    def __init__(self) -> None:
+        self.value = 42
 
 
 def test_benchmark_diwire_enter_close_scope_resolve_once(benchmark: Any) -> None:
@@ -64,6 +72,24 @@ def test_benchmark_dishka_enter_close_scope_resolve_once(benchmark: Any) -> None
 
     benchmark.pedantic(
         target=bench_dishka_enter_scope,
+        warmup_rounds=_BENCHMARK_WARMUP_ROUNDS,
+        rounds=_BENCHMARK_ROUNDS,
+        iterations=_BENCHMARK_ITERATIONS,
+    )
+
+
+def test_benchmark_wireup_enter_close_scope_resolve_once(benchmark: Any) -> None:
+    container = make_wireup_benchmark_container(_SingletonValue)
+    assert container.get(_SingletonValue).value == 42
+    with container.enter_scope() as scope:
+        assert scope.get(_SingletonValue).value == 42
+
+    def bench_wireup_enter_scope() -> None:
+        with container.enter_scope() as scope:
+            _ = scope.get(_SingletonValue)
+
+    benchmark.pedantic(
+        target=bench_wireup_enter_scope,
         warmup_rounds=_BENCHMARK_WARMUP_ROUNDS,
         rounds=_BENCHMARK_ROUNDS,
         iterations=_BENCHMARK_ITERATIONS,

--- a/tests/benchmarks/test_resolve_singleton.py
+++ b/tests/benchmarks/test_resolve_singleton.py
@@ -5,12 +5,15 @@ from typing import Any
 import punq
 import rodi
 from dishka import Provider
+from wireup import injectable
 
 from diwire import Lifetime
 from tests.benchmarks.dishka_helpers import DishkaBenchmarkScope, make_dishka_benchmark_container
 from tests.benchmarks.helpers import make_diwire_benchmark_container, run_benchmark
+from tests.benchmarks.wireup_helpers import make_wireup_benchmark_container
 
 
+@injectable(lifetime="singleton")
 class _SingletonService:
     pass
 
@@ -55,6 +58,18 @@ def test_benchmark_dishka_resolve_singleton(benchmark: Any) -> None:
         _ = container.get(_SingletonService)
 
     run_benchmark(benchmark, bench_dishka_singleton)
+
+
+def test_benchmark_wireup_resolve_singleton(benchmark: Any) -> None:
+    container = make_wireup_benchmark_container(_SingletonService)
+    first = container.get(_SingletonService)
+    second = container.get(_SingletonService)
+    assert first is second
+
+    def bench_wireup_singleton() -> None:
+        _ = container.get(_SingletonService)
+
+    run_benchmark(benchmark, bench_wireup_singleton)
 
 
 def test_benchmark_punq_resolve_singleton(benchmark: Any) -> None:

--- a/tests/benchmarks/test_resolve_transient.py
+++ b/tests/benchmarks/test_resolve_transient.py
@@ -5,12 +5,15 @@ from typing import Any
 import punq
 import rodi
 from dishka import Provider
+from wireup import injectable
 
 from diwire import Lifetime
 from tests.benchmarks.dishka_helpers import DishkaBenchmarkScope, make_dishka_benchmark_container
 from tests.benchmarks.helpers import make_diwire_benchmark_container, run_benchmark
+from tests.benchmarks.wireup_helpers import make_wireup_benchmark_container
 
 
+@injectable(lifetime="transient")
 class _TransientService:
     pass
 
@@ -55,6 +58,19 @@ def test_benchmark_dishka_resolve_transient(benchmark: Any) -> None:
         _ = container.get(_TransientService)
 
     run_benchmark(benchmark, bench_dishka_transient)
+
+
+def test_benchmark_wireup_resolve_transient(benchmark: Any) -> None:
+    container = make_wireup_benchmark_container(_TransientService)
+    with container.enter_scope() as scope:
+        first = scope.get(_TransientService)
+        second = scope.get(_TransientService)
+        assert first is not second
+
+        def bench_wireup_transient() -> None:
+            _ = scope.get(_TransientService)
+
+        run_benchmark(benchmark, bench_wireup_transient)
 
 
 def test_benchmark_punq_resolve_transient(benchmark: Any) -> None:

--- a/tests/benchmarks/test_resolve_wide_transient_graph.py
+++ b/tests/benchmarks/test_resolve_wide_transient_graph.py
@@ -5,32 +5,40 @@ from typing import Any
 import punq
 import rodi
 from dishka import Provider
+from wireup import injectable
 
 from diwire import Lifetime
 from tests.benchmarks.dishka_helpers import DishkaBenchmarkScope, make_dishka_benchmark_container
 from tests.benchmarks.helpers import make_diwire_benchmark_container, run_benchmark
+from tests.benchmarks.wireup_helpers import make_wireup_benchmark_container
 
 
+@injectable(lifetime="transient")
 class _DepA:
     pass
 
 
+@injectable(lifetime="transient")
 class _DepB:
     pass
 
 
+@injectable(lifetime="transient")
 class _DepC:
     pass
 
 
+@injectable(lifetime="transient")
 class _DepD:
     pass
 
 
+@injectable(lifetime="transient")
 class _DepE:
     pass
 
 
+@injectable(lifetime="transient")
 class _Root:
     def __init__(
         self,
@@ -117,6 +125,24 @@ def test_benchmark_dishka_resolve_wide_transient_graph(benchmark: Any) -> None:
         _ = container.get(_Root)
 
     run_benchmark(benchmark, bench_dishka_wide_graph, iterations=25_000)
+
+
+def test_benchmark_wireup_resolve_wide_transient_graph(benchmark: Any) -> None:
+    container = make_wireup_benchmark_container(_DepA, _DepB, _DepC, _DepD, _DepE, _Root)
+    with container.enter_scope() as scope:
+        first = scope.get(_Root)
+        second = scope.get(_Root)
+        assert first is not second
+        assert first.dep_a is not second.dep_a
+        assert first.dep_b is not second.dep_b
+        assert first.dep_c is not second.dep_c
+        assert first.dep_d is not second.dep_d
+        assert first.dep_e is not second.dep_e
+
+        def bench_wireup_wide_graph() -> None:
+            _ = scope.get(_Root)
+
+        run_benchmark(benchmark, bench_wireup_wide_graph, iterations=25_000)
 
 
 def test_benchmark_punq_resolve_wide_transient_graph(benchmark: Any) -> None:

--- a/tests/benchmarks/wireup_helpers.py
+++ b/tests/benchmarks/wireup_helpers.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+from wireup import SyncContainer, create_sync_container
+
+
+def make_wireup_benchmark_container(*injectables: Any) -> SyncContainer:
+    return create_sync_container(
+        injectables=list(injectables),
+        concurrent_scoped_access=False,
+    )

--- a/tools/benchmark_reporting.py
+++ b/tools/benchmark_reporting.py
@@ -8,8 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Final, cast
 
-KNOWN_BENCHMARK_LIBRARIES: Final[tuple[str, ...]] = ("diwire", "rodi", "dishka", "punq")
-DEFAULT_BENCHMARK_LIBRARIES: Final[tuple[str, ...]] = ("diwire", "rodi", "dishka")
+KNOWN_BENCHMARK_LIBRARIES: Final[tuple[str, ...]] = ("diwire", "rodi", "dishka", "wireup", "punq")
+DEFAULT_BENCHMARK_LIBRARIES: Final[tuple[str, ...]] = ("diwire", "rodi", "dishka", "wireup")
 OPTIONAL_BENCHMARK_LIBRARIES: Final[tuple[str, ...]] = ("punq",)
 _BENCHMARK_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(
     r"^test_benchmark_(?P<library>[a-z0-9]+)_",
@@ -66,7 +66,7 @@ class BenchmarkReport:
         }
 
         # Compatibility keys for the historically published schema.
-        for baseline in ("rodi", "dishka"):
+        for baseline in ("rodi", "dishka", "wireup"):
             if baseline in self.speedups:
                 normalized[f"speedup_diwire_over_{baseline}"] = {
                     scenario: value
@@ -238,7 +238,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--libraries",
         default=",".join(DEFAULT_BENCHMARK_LIBRARIES),
-        help="Comma-separated list of libraries to include (default: diwire,rodi,dishka).",
+        help="Comma-separated list of libraries to include (default: diwire,rodi,dishka,wireup).",
     )
     parser.add_argument(
         "--scenarios",

--- a/uv.lock
+++ b/uv.lock
@@ -377,6 +377,7 @@ dev = [
     { name = "ty" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
+    { name = "wireup" },
 ]
 docs = [
     { name = "furo" },
@@ -413,6 +414,7 @@ dev = [
     { name = "ty", specifier = ">=0.0.15" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
+    { name = "wireup", specifier = ">=2.7.0" },
 ]
 docs = [
     { name = "furo", specifier = ">=2025.12.19" },
@@ -501,7 +503,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/65/5b235b40581ad75ab97dcd8b4218022ae8e3ab77c13c919f1a1dfe9171fd/greenlet-3.3.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:04bee4775f40ecefcdaa9d115ab44736cd4b9c5fba733575bfe9379419582e13", size = 273723, upload-time = "2026-01-23T15:30:37.521Z" },
     { url = "https://files.pythonhosted.org/packages/ce/ad/eb4729b85cba2d29499e0a04ca6fbdd8f540afd7be142fd571eea43d712f/greenlet-3.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e1457f4fed12a50e427988a07f0f9df53cf0ee8da23fab16e6732c2ec909d4", size = 574874, upload-time = "2026-01-23T16:00:54.551Z" },
     { url = "https://files.pythonhosted.org/packages/87/32/57cad7fe4c8b82fdaa098c89498ef85ad92dfbb09d5eb713adedfc2ae1f5/greenlet-3.3.1-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:070472cd156f0656f86f92e954591644e158fd65aa415ffbe2d44ca77656a8f5", size = 586309, upload-time = "2026-01-23T16:05:25.18Z" },
-    { url = "https://files.pythonhosted.org/packages/66/66/f041005cb87055e62b0d68680e88ec1a57f4688523d5e2fb305841bc8307/greenlet-3.3.1-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1108b61b06b5224656121c3c8ee8876161c491cbe74e5c519e0634c837cf93d5", size = 597461, upload-time = "2026-01-23T16:15:51.943Z" },
     { url = "https://files.pythonhosted.org/packages/87/eb/8a1ec2da4d55824f160594a75a9d8354a5fe0a300fb1c48e7944265217e1/greenlet-3.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a300354f27dd86bae5fbf7002e6dd2b3255cd372e9242c933faf5e859b703fe", size = 586985, upload-time = "2026-01-23T15:32:47.968Z" },
     { url = "https://files.pythonhosted.org/packages/15/1c/0621dd4321dd8c351372ee8f9308136acb628600658a49be1b7504208738/greenlet-3.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e84b51cbebf9ae573b5fbd15df88887815e3253fc000a7d0ff95170e8f7e9729", size = 1547271, upload-time = "2026-01-23T16:04:18.977Z" },
     { url = "https://files.pythonhosted.org/packages/9d/53/24047f8924c83bea7a59c8678d9571209c6bfe5f4c17c94a78c06024e9f2/greenlet-3.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0093bd1a06d899892427217f0ff2a3c8f306182b8c754336d32e2d587c131b4", size = 1613427, upload-time = "2026-01-23T15:33:44.428Z" },
@@ -509,7 +510,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
     { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
     { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161, upload-time = "2026-01-23T16:15:53.456Z" },
     { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272, upload-time = "2026-01-23T15:32:49.411Z" },
     { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729, upload-time = "2026-01-23T16:04:20.867Z" },
     { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552, upload-time = "2026-01-23T15:33:45.743Z" },
@@ -518,7 +518,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
     { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
     { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
     { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
     { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
@@ -527,7 +526,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
-    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -536,7 +534,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
     { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
     { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
@@ -545,7 +542,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
     { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
     { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
@@ -1776,6 +1772,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "wireup"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/a3/2260e45ca5afda881b86357ab9f7b53d8e286eccfc8a02b0b8687f7612f3/wireup-2.7.0.tar.gz", hash = "sha256:4fc980a33ffa156e4d45eb383fe4953ed088bb597cf607cefa1eeace58c20545", size = 558220, upload-time = "2026-02-09T22:47:00.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/ef/3398adc36d711c43977b62cafb2f507ebaeb88eb884fec09aa97c320e141/wireup-2.7.0-py3-none-any.whl", hash = "sha256:53aaf6b57ca0ede1edf1d6da840ddda454a12dc9d0afa05e41eb373912fc378e", size = 48475, upload-time = "2026-02-09T22:47:01.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# PR Summary

## What changed

- Added `wireup` to the benchmark suite (targets, reporting, helpers, and lockfile), and updated docs to include it in comparisons.
- Updated benchmark reporting to compute and display wireup speedups alongside existing libraries.
- Improved DI resolution behavior for dataclass `default_factory` parameters in strict mode by treating them as fallbacks when no dependency is registered.
- Added tests for dataclass `default_factory` behavior and strict-mode edge cases.
- Added a new example and documentation entry for dataclass default factory fallback behavior in strict mode.

## Why it matters

- Expands benchmark coverage with a fourth library baseline.
- Improves user-facing strict-mode ergonomics: factory defaults now work as expected while explicit registrations still take precedence.
- Strengthens correctness around unresolved dataclass dependencies and documents the behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for dataclass default_factory parameters in dependency resolution
  * Integrated wireup into performance benchmarks and comparisons

* **Documentation**
  * Updated performance benchmarks with current results and Python 3.14.2
  * Added example demonstrating dataclass default_factory usage in strict mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->