### PR TITLE
docs: add support for extensionless redirects in sitemap generation

### DIFF
--- a/docs/_extensions/diwire_sitemap.py
+++ b/docs/_extensions/diwire_sitemap.py
@@ -7,6 +7,7 @@ dependencies into the library.
 from __future__ import annotations
 
 import contextlib
+import html
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -39,6 +40,22 @@ class _SitemapEntry:
     lastmod: str
 
 
+def _canonical_path_from_html_rel(rel: str) -> str:
+    if rel == "index.html":
+        return "/"
+    if rel.endswith("/index.html"):
+        return f"/{rel.removesuffix('index.html')}"
+    return f"/{rel.removesuffix('.html')}/"
+
+
+def _is_generated_redirect_index(rel: str, *, outdir: Path) -> bool:
+    if not rel.endswith("/index.html"):
+        return False
+
+    non_index_rel = f"{rel.removesuffix('/index.html')}.html"
+    return (outdir / non_index_rel).is_file()
+
+
 def _iter_html_files(outdir: Path) -> list[Path]:
     # Sphinx outputs a lot of internal files; we only want real pages.
     html_files: list[Path] = []
@@ -48,6 +65,8 @@ def _iter_html_files(outdir: Path) -> list[Path]:
             continue
         if rel in {"genindex.html", "search.html"}:
             continue
+        if _is_generated_redirect_index(rel, outdir=outdir):
+            continue
         html_files.append(path)
 
     # Stable ordering helps keep diffs small (and makes local debugging nicer).
@@ -56,11 +75,11 @@ def _iter_html_files(outdir: Path) -> list[Path]:
 
 
 def _build_entries(outdir: Path, *, baseurl: str) -> list[_SitemapEntry]:
-    base = baseurl.rstrip("/") + "/"
+    base = baseurl.rstrip("/")
     entries: list[_SitemapEntry] = []
     for html_path in _iter_html_files(outdir):
         rel = html_path.relative_to(outdir).as_posix()
-        loc = base + rel
+        loc = f"{base}{_canonical_path_from_html_rel(rel)}"
         lastmod = (
             datetime.fromtimestamp(html_path.stat().st_mtime, tz=timezone.utc).date().isoformat()
         )
@@ -102,6 +121,49 @@ def _write_robots(outdir: Path, *, baseurl: str) -> None:
     (outdir / "robots.txt").write_text(content, encoding="utf-8")
 
 
+def _render_redirect_page(*, target_href: str, canonical_url: str) -> str:
+    escaped_target = html.escape(target_href, quote=True)
+    escaped_canonical = html.escape(canonical_url, quote=True)
+    return "\n".join(
+        [
+            "<!doctype html>",
+            '<html lang="en">',
+            "  <head>",
+            '    <meta charset="utf-8">',
+            "    <title>Redirecting...</title>",
+            f'    <link rel="canonical" href="{escaped_canonical}">',
+            f'    <meta http-equiv="refresh" content="0; url={escaped_target}">',
+            f'    <script>window.location.replace("{escaped_target}");</script>',
+            "  </head>",
+            "  <body>",
+            f'    <p>Redirecting to <a href="{escaped_target}">{escaped_target}</a>.</p>',
+            "  </body>",
+            "</html>",
+            "",
+        ],
+    )
+
+
+def _write_extensionless_redirects(outdir: Path, *, html_files: list[Path], baseurl: str) -> None:
+    base = baseurl.rstrip("/")
+    for html_path in html_files:
+        rel = html_path.relative_to(outdir).as_posix()
+        if rel.endswith("index.html"):
+            continue
+
+        source_name = Path(rel).name
+        redirect_rel = Path(rel).with_suffix("") / "index.html"
+        redirect_path = outdir / redirect_rel
+        redirect_path.parent.mkdir(parents=True, exist_ok=True)
+
+        canonical_url = f"{base}{_canonical_path_from_html_rel(rel)}"
+        redirect_html = _render_redirect_page(
+            target_href=f"../{source_name}",
+            canonical_url=canonical_url,
+        )
+        redirect_path.write_text(redirect_html, encoding="utf-8")
+
+
 def _build_finished(app: _SphinxApp, exc: Exception | None) -> None:
     if exc is not None:
         return
@@ -113,6 +175,11 @@ def _build_finished(app: _SphinxApp, exc: Exception | None) -> None:
         return
 
     outdir = Path(app.outdir)
+    html_files = _iter_html_files(outdir)
+    if not html_files:
+        return
+
+    _write_extensionless_redirects(outdir, html_files=html_files, baseurl=baseurl)
     entries = _build_entries(outdir, baseurl=baseurl)
     if not entries:
         return

--- a/tests/docs/test_diwire_sitemap.py
+++ b/tests/docs/test_diwire_sitemap.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").is_file() and (candidate / "src" / "diwire").is_dir():
+            return candidate
+    msg = f"Could not locate repository root from {start}"
+    raise AssertionError(msg)
+
+
+def _load_sitemap_module(repo_root: Path) -> ModuleType:
+    module_path = repo_root / "docs" / "_extensions" / "diwire_sitemap.py"
+    module_name = "diwire_sitemap_test_module"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module from {module_path}"
+        raise AssertionError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_html(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("<html><body>ok</body></html>\n", encoding="utf-8")
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+SITEMAP: Any = _load_sitemap_module(REPO_ROOT)
+
+
+def test_canonical_path_from_html_rel_maps_expected_shapes() -> None:
+    assert SITEMAP._canonical_path_from_html_rel("index.html") == "/"
+    assert SITEMAP._canonical_path_from_html_rel("core/index.html") == "/core/"
+    assert SITEMAP._canonical_path_from_html_rel("core/async.html") == "/core/async/"
+
+
+def test_write_extensionless_redirects_creates_redirect_for_non_index_pages(tmp_path: Path) -> None:
+    source_html = tmp_path / "core" / "async.html"
+    _write_html(source_html)
+
+    SITEMAP._write_extensionless_redirects(
+        tmp_path,
+        html_files=[source_html],
+        baseurl="https://docs.example.dev",
+    )
+
+    redirect_path = tmp_path / "core" / "async" / "index.html"
+    assert redirect_path.is_file()
+
+    redirect_html = redirect_path.read_text(encoding="utf-8")
+    assert '<link rel="canonical" href="https://docs.example.dev/core/async/">' in redirect_html
+    assert '<meta http-equiv="refresh" content="0; url=../async.html">' in redirect_html
+    assert 'window.location.replace("../async.html");' in redirect_html
+
+
+def test_write_extensionless_redirects_skips_index_pages(tmp_path: Path) -> None:
+    root_index = tmp_path / "index.html"
+    section_index = tmp_path / "core" / "index.html"
+    _write_html(root_index)
+    _write_html(section_index)
+
+    SITEMAP._write_extensionless_redirects(
+        tmp_path,
+        html_files=[root_index, section_index],
+        baseurl="https://docs.example.dev",
+    )
+
+    assert not (tmp_path / "index" / "index.html").exists()
+    assert not (tmp_path / "core" / "index" / "index.html").exists()
+
+
+def test_build_entries_uses_extensionless_canonical_urls(tmp_path: Path) -> None:
+    _write_html(tmp_path / "index.html")
+    _write_html(tmp_path / "core" / "index.html")
+    _write_html(tmp_path / "core" / "async.html")
+
+    entries = SITEMAP._build_entries(tmp_path, baseurl="https://docs.example.dev")
+    locs = {entry.loc for entry in entries}
+
+    assert locs == {
+        "https://docs.example.dev/",
+        "https://docs.example.dev/core/",
+        "https://docs.example.dev/core/async/",
+    }
+
+
+def test_build_entries_ignores_generated_redirect_index_pages(tmp_path: Path) -> None:
+    _write_html(tmp_path / "core" / "async.html")
+    _write_html(tmp_path / "core" / "async" / "index.html")
+
+    entries = SITEMAP._build_entries(tmp_path, baseurl="https://docs.example.dev")
+    locs = [entry.loc for entry in entries]
+
+    assert locs == ["https://docs.example.dev/core/async/"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation now emits extensionless redirect pages so URLs without file extensions resolve to friendly canonical pages.

* **Improvements**
  * Sitemap and robots generation use consistent canonical URLs (trailing-slash handling improved) and ignore auto-generated redirect index pages for cleaner SEO.
  * Redirect pages include proper canonical links and client-side refresh for reliable navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->