### PR TITLE
feat: stip non-component annotated extra

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -32,18 +32,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      - name: Run benchmark suite
-        run: |
-          mkdir -p benchmark-results
-          uv run pytest tests/benchmarks --benchmark-only -q --benchmark-json=benchmark-results/raw-benchmark.json
-
-      - name: Generate benchmark table artifacts
-        run: |
-          uv run python -m tools.benchmark_reporting \
-            --input benchmark-results/raw-benchmark.json \
-            --markdown benchmark-results/benchmark-table.md \
-            --json benchmark-results/benchmark-table.json \
-            --comment benchmark-results/pr-comment.md
+      - name: Run benchmark comparison report
+        run: make benchmark-report
 
       - name: Upload benchmark artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint test docs examples-readme benchmark benchmark-json benchmark-report benchmark-report-all benchmark-json-resolve benchmark-report-resolve
+.PHONY: format lint test docs examples-readme benchmark benchmark-diwire benchmark-comparison benchmark-json benchmark-report benchmark-report-all benchmark-json-resolve benchmark-report-resolve
 
 format:
 	uv run ruff format .
@@ -27,17 +27,13 @@ examples-readme:
 # === Benchmark Commands ===
 
 benchmark:
-	uv run pytest tests/benchmarks/test_enter_close_scope_no_resolve.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_enter_close_scope_resolve_once.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_enter_close_scope_resolve_100_instance.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_enter_close_scope_resolve_scoped_100.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_resolve_deep_transient_chain.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_resolve_wide_transient_graph.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_resolve_singleton.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_resolve_transient.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_resolve_scoped.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_resolve_mixed_lifetimes.py --benchmark-only --benchmark-columns=ops -q
-	uv run pytest tests/benchmarks/test_resolve_generated_scoped_grid.py --benchmark-only --benchmark-columns=ops -q
+	$(MAKE) benchmark-diwire
+
+benchmark-diwire:
+	uv run pytest tests/benchmarks -k "benchmark_diwire" --benchmark-only --benchmark-columns=ops -q
+
+benchmark-comparison:
+	uv run pytest tests/benchmarks --benchmark-only --benchmark-columns=ops -q
 
 benchmark-json:
 	mkdir -p benchmark-results

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ In this benchmark suite on CPython ``3.14.3`` (Apple M3 Pro, strict mode):
 - Resolve-only comparisons (scope-capable libraries): speedup ranges are **2.55×–3.64×** (``rodi``), **2.72×–4.14×** (``dishka``), and **1.81×–3.10×** (``wireup``).
 - Current benchmark totals: **11** full-suite scenarios and **5** resolve-only scenarios.
 
-Results vary by environment, Python version, and hardware. Re-run ``make benchmark-report`` and
-``make benchmark-report-resolve`` on your target runtime before drawing final conclusions for production workloads.
+For quick local regression checks, run ``make benchmark`` (diwire-only).
+For full cross-library runs, use ``make benchmark-comparison`` (raw suite) or
+``make benchmark-report`` / ``make benchmark-report-resolve`` (report artifacts).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ Benchmarks + methodology live in the docs: [Performance](https://docs.diwire.dev
 
 In this benchmark suite on CPython ``3.14.3`` (Apple M3 Pro, strict mode):
 
-- Speedup over ``rodi`` ranges from **1.60×** to **5.75×**.
-- Speedup over ``dishka`` ranges from **2.74×** to **30.58×**.
-- Speedup over ``wireup`` ranges from **1.95×** to **4.94×**.
-- Resolve-only comparisons (scope-capable libraries): speedup ranges are **2.55×–3.64×** (``rodi``), **2.72×–4.14×** (``dishka``), and **1.81×–3.10×** (``wireup``).
+- diwire is the top performer across this suite, reaching up to **6.89×** vs ``rodi``, **30.79×** vs ``dishka``, and **4.40×** vs ``wireup``.
+- Resolve-only comparisons (scope-capable libraries): diwire reaches up to **3.64×** (``rodi``), **4.14×** (``dishka``), and **3.10×** (``wireup``).
 - Current benchmark totals: **11** full-suite scenarios and **5** resolve-only scenarios.
 
 For quick local regression checks, run ``make benchmark`` (diwire-only).

--- a/docs/core/components.rst
+++ b/docs/core/components.rst
@@ -46,6 +46,17 @@ first by passing ``component=...``:
 The same shortcut is available on ``add``, ``add_factory``,
 ``add_generator``, ``add_context_manager``, and ``decorate``.
 
+Metadata normalization
+----------------------
+
+For dependency key identity, DIWire strips all non-``Component`` ``Annotated`` metadata.
+
+- ``Annotated[T, \"meta\"]`` is treated as ``T``.
+- ``Annotated[T, Component(\"x\"), \"meta\"]`` is treated as ``Annotated[T, Component(\"x\")]``.
+- Only ``Component(...)`` metadata differentiates registrations.
+
+Runnable example: :doc:`/howto/examples/annotation-normalization`.
+
 
 Resolve all components
 ----------------------

--- a/docs/core/function-injection.rst
+++ b/docs/core/function-injection.rst
@@ -62,6 +62,7 @@ FromContext in injected callables
 
 Inject wrappers can resolve ``FromContext[T]`` parameters from scope context values.
 Pass context with reserved kwarg ``diwire_context`` when the wrapper opens a new scope.
+For ``Annotated`` keys, non-``Component`` metadata is ignored for context lookup identity.
 
 .. code-block:: python
    :class: diwire-example py-run

--- a/docs/core/scopes.rst
+++ b/docs/core/scopes.rst
@@ -61,5 +61,11 @@ Scope context values
 You can attach per-scope context values when entering a scope and resolve them via ``FromContext[T]`` in providers or
 in injected callables.
 
-Runnable example: :doc:`/howto/examples/scope-context-values`.
+Context key normalization follows the same rule as dependency keys:
 
+- ``FromContext[Annotated[T, \"meta\"]]`` looks up ``T``.
+- ``FromContext[Annotated[T, Component(\"x\"), \"meta\"]]`` looks up
+  ``Annotated[T, Component(\"x\")]``.
+
+Runnable examples: :doc:`/howto/examples/scope-context-values`,
+:doc:`/howto/examples/annotation-normalization`.

--- a/docs/howto/advanced/performance.rst
+++ b/docs/howto/advanced/performance.rst
@@ -19,7 +19,19 @@ Why it’s fast
 Benchmark methodology
 ---------------------
 
-To reproduce locally:
+For fast local diwire-only checks:
+
+.. code-block:: bash
+
+   make benchmark
+
+For full cross-library comparison (raw benchmark run):
+
+.. code-block:: bash
+
+   make benchmark-comparison
+
+To reproduce the published comparison artifacts locally:
 
 .. code-block:: bash
 
@@ -162,8 +174,9 @@ Summary (computed from the table above):
 - Speedup over dishka ranges from **2.74×** to **30.58×**.
 - Speedup over wireup ranges from **1.95×** to **4.94×**.
 
-Results vary by environment, Python version, and hardware. Re-run ``make benchmark-report`` on your target runtime
-before drawing final conclusions for production workloads.
+Results vary by environment, Python version, and hardware. Re-run ``make benchmark-comparison`` for raw comparisons
+or ``make benchmark-report`` for generated comparison artifacts on your target runtime before drawing final
+conclusions for production workloads.
 
 Resolve-only comparisons (scope-capable libraries)
 --------------------------------------------------

--- a/docs/howto/examples/annotation-normalization.rst
+++ b/docs/howto/examples/annotation-normalization.rst
@@ -1,0 +1,41 @@
+.. meta::
+   :description: diwire annotation normalization examples: non-component Annotated metadata is stripped from dependency keys.
+
+Annotation normalization
+========================
+
+What you'll learn
+-----------------
+
+- ``Annotated[T, <non-component-meta>]`` resolves the same as ``T``.
+- ``Annotated[T, Component(\"name\"), <non-component-meta>]`` resolves the same as
+  ``Annotated[T, Component(\"name\")]``.
+- ``FromContext[Annotated[T, <non-component-meta>]]`` looks up the normalized context key.
+
+Registration and resolve key normalization
+------------------------------------------
+
+Run locally
+~~~~~~~~~~~
+
+.. code-block:: bash
+
+   uv run python examples/ex_24_annotation_normalization/01_registration_keys.py
+
+.. literalinclude:: ../../../examples/ex_24_annotation_normalization/01_registration_keys.py
+   :language: python
+   :class: diwire-example py-run
+
+FromContext key normalization
+-----------------------------
+
+Run locally
+~~~~~~~~~~~
+
+.. code-block:: bash
+
+   uv run python examples/ex_24_annotation_normalization/02_from_context_keys.py
+
+.. literalinclude:: ../../../examples/ex_24_annotation_normalization/02_from_context_keys.py
+   :language: python
+   :class: diwire-example py-run

--- a/docs/howto/examples/index.rst
+++ b/docs/howto/examples/index.rst
@@ -21,6 +21,7 @@ Each page below includes one or more focused, self-contained scripts sourced *ve
    scope-context-values
    function-injection
    named-components
+   annotation-normalization
    providers
    compilation
    open-generics

--- a/docs/howto/examples/scope-context-values.rst
+++ b/docs/howto/examples/scope-context-values.rst
@@ -55,6 +55,10 @@ Run locally
 Annotated context keys
 ----------------------
 
+Only ``Component(...)`` metadata is identity-bearing. Non-component metadata is
+stripped when resolving context keys. See also
+:doc:`/howto/examples/annotation-normalization`.
+
 Run locally
 ~~~~~~~~~~~
 

--- a/examples/ex_24_annotation_normalization/01_registration_keys.py
+++ b/examples/ex_24_annotation_normalization/01_registration_keys.py
@@ -1,0 +1,39 @@
+"""Non-component Annotated metadata is normalized out of dependency keys."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from diwire import Component, Container
+
+
+@dataclass(slots=True)
+class Service:
+    source: str
+
+
+def main() -> None:
+    container = Container()
+
+    container.add_instance(Service(source="base"), provides=Annotated[Service, "plain-meta"])
+    container.add_instance(
+        Service(source="component"),
+        provides=Annotated[Service, Component("primary"), "extra-meta"],
+    )
+
+    base_direct = container.resolve(Service)
+    base_annotated = container.resolve(Annotated[Service, "another-meta"])
+    component_direct = container.resolve(Annotated[Service, Component("primary")])
+    component_annotated = container.resolve(
+        Annotated[Service, Component("primary"), "different-meta"],
+    )
+
+    print(f"base_direct={base_direct.source}")  # => base_direct=base
+    print(f"base_annotated={base_annotated.source}")  # => base_annotated=base
+    print(f"component_direct={component_direct.source}")  # => component_direct=component
+    print(f"component_annotated={component_annotated.source}")  # => component_annotated=component
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ex_24_annotation_normalization/02_from_context_keys.py
+++ b/examples/ex_24_annotation_normalization/02_from_context_keys.py
@@ -1,0 +1,31 @@
+"""FromContext keys also ignore non-component Annotated metadata."""
+
+from __future__ import annotations
+
+from typing import Annotated, TypeAlias
+
+from diwire import Component, Container, FromContext, Scope
+
+Priority: TypeAlias = Annotated[int, Component("priority")]
+PriorityWithMeta: TypeAlias = Annotated[int, Component("priority"), "meta"]
+
+
+def main() -> None:
+    container = Container()
+
+    with container.enter_scope(
+        Scope.REQUEST,
+        context={
+            int: 7,
+            Priority: 42,
+        },
+    ) as request_scope:
+        plain = request_scope.resolve(FromContext[Annotated[int, "request-id"]])
+        component = request_scope.resolve(FromContext[PriorityWithMeta])
+
+    print(f"plain={plain}")  # => plain=7
+    print(f"component={component}")  # => component=42
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/internal/test_container_open_generics.py
+++ b/tests/unit/internal/test_container_open_generics.py
@@ -111,6 +111,16 @@ def test_open_concrete_registration_resolves_closed_generic_requests() -> None:
     assert resolved.type is str
 
 
+def test_open_concrete_registration_resolves_non_component_annotated_closed_key() -> None:
+    container = Container()
+    container.add(_Box, provides=_IBox)
+
+    resolved = container.resolve(Annotated[_IBox[int], "meta"])
+
+    assert isinstance(resolved, _Box)
+    assert resolved.type is int
+
+
 def test_closed_registration_wins_over_open_template() -> None:
     container = Container()
     container.add(_Box, provides=_IBox)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency resolution now ignores non-component Annotated metadata, preventing lookup mismatches.

* **New Features**
  * Public symbol for component-qualified annotations is now exportable for use in annotations.

* **Documentation**
  * Added "Annotation normalization" docs and runnable examples; updated context/scope docs.
  * Streamlined benchmark instructions: quick local diwire-only check and full cross-library comparison via make targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->