### PR TITLE
docs(django-modern-rest): add integration documentation

### DIFF
--- a/docs/howto/web/_snippets/django_modern_rest.txt
+++ b/docs/howto/web/_snippets/django_modern_rest.txt
@@ -1,0 +1,64 @@
+import django
+
+from django.apps import apps
+from django.conf import settings
+from django.http import HttpRequest
+from django.urls import path
+from pydantic import BaseModel
+
+from dmr import Controller
+from dmr.plugins.pydantic import PydanticSerializer
+
+from diwire import Container, Injected, Lifetime, Scope, resolver_context
+from diwire.integrations.django import add_request_context
+
+if not settings.configured:
+    settings.configure(
+        ALLOWED_HOSTS=["*"],
+        INSTALLED_APPS=[],
+        SECRET_KEY="docs-example-secret",
+    )
+
+if not apps.ready:
+    django.setup()
+
+container = Container()
+add_request_context(container)
+
+
+class PathResponse(BaseModel):
+    direct_path: str
+    service_path: str
+
+
+class RequestPathService:
+    def __init__(self, request: HttpRequest) -> None:
+        self._request = request
+
+    def path(self) -> str:
+        return self._request.path
+
+
+container.add(
+    RequestPathService,
+    scope=Scope.REQUEST,
+    lifetime=Lifetime.SCOPED,
+)
+
+
+class PathController(Controller[PydanticSerializer]):
+    @resolver_context.inject(scope=Scope.REQUEST)
+    def get(
+        self,
+        request: Injected[HttpRequest],
+        service: Injected[RequestPathService],
+    ) -> PathResponse:
+        return PathResponse(
+            direct_path=request.path,
+            service_path=service.path(),
+        )
+
+
+urlpatterns = [
+    path("api/path/", PathController.as_view()),
+]

--- a/docs/howto/web/_snippets/django_modern_rest_test.txt
+++ b/docs/howto/web/_snippets/django_modern_rest_test.txt
@@ -1,0 +1,14 @@
+from django.test import override_settings
+
+from dmr.test import DMRClient
+
+with override_settings(
+    ROOT_URLCONF=__name__,
+    MIDDLEWARE=["diwire.integrations.django.RequestContextMiddleware"],
+):
+    response = DMRClient().get("/api/path/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "direct_path": "/api/path/",
+        "service_path": "/api/path/",
+    }

--- a/docs/howto/web/django-modern-rest.rst
+++ b/docs/howto/web/django-modern-rest.rst
@@ -1,0 +1,71 @@
+.. meta::
+   :description: How to use diwire with django-modern-rest controllers: request-scoped injection via RequestContextMiddleware and add_request_context(container).
+   :keywords: django-modern-rest dependency injection, dmr dependency injection, django request scope, python dependency injection django
+
+django-modern-rest
+==================
+
+``django-modern-rest`` is built on top of Django's regular request lifecycle, so the diwire
+integration is the same one you use for plain Django views:
+
+- :class:`diwire.integrations.django.RequestContextMiddleware` stores the current
+  :class:`django.http.HttpRequest` in a ``contextvars.ContextVar`` for the duration of a request.
+- :func:`diwire.integrations.django.add_request_context` registers ``HttpRequest`` in your
+  :class:`diwire.Container`, so controller methods and request-scoped services can depend on it.
+
+The package is installed from PyPI as ``django-modern-rest``, but current releases expose their
+runtime API from the ``dmr`` module.
+
+Minimal setup
+-------------
+
+.. code-block:: python
+
+   # settings.py
+   MIDDLEWARE = [
+       # ...
+       "diwire.integrations.django.RequestContextMiddleware",
+       # ...
+   ]
+
+.. literalinclude:: _snippets/django_modern_rest.txt
+   :language: python
+
+Inject ``HttpRequest`` in controllers and services
+--------------------------------------------------
+
+``django-modern-rest`` controllers are regular Django ``View`` subclasses, so diwire works well
+on controller methods decorated with ``@resolver_context.inject(scope=Scope.REQUEST)``.
+
+This gives you the same benefits as plain Django integration:
+
+- inject the active request directly into controller methods
+- inject the same request into request-scoped services
+
+Response handling
+-----------------
+
+``django-modern-rest`` validates and serializes controller responses. Prefer returning typed data
+or using controller helpers like ``self.to_response(...)`` / ``self.to_error(...)`` instead of
+constructing raw Django ``HttpResponse`` objects yourself.
+
+Testing
+-------
+
+For in-process tests, you can use :class:`dmr.test.DMRClient` (or Django's normal test client) and
+keep the same diwire setup: install ``RequestContextMiddleware``, call
+``add_request_context(container)``, and route your controller with ``.as_view()``.
+
+.. literalinclude:: _snippets/django_modern_rest_test.txt
+   :language: python
+
+How it works
+------------
+
+1. Django receives a request and executes ``RequestContextMiddleware``.
+2. The middleware stores the active ``HttpRequest`` in a ``ContextVar``.
+3. ``django-modern-rest`` instantiates the controller and dispatches the matching endpoint.
+4. ``@resolver_context.inject(scope=Scope.REQUEST)`` opens a request scope, resolves
+   ``Injected[...]`` parameters, and calls the controller method.
+5. After the controller method returns, the injected wrapper ends request-scoped resolution and the
+   middleware resets request context.

--- a/docs/howto/web/django.rst
+++ b/docs/howto/web/django.rst
@@ -8,6 +8,9 @@ Django
 The Django integration provides request-scoped dependency resolution for views using the same
 ``Injected[T]`` pattern as other diwire web integrations.
 
+If your Django views are implemented with ``django-modern-rest`` controllers, see
+:doc:`django-modern-rest`.
+
 Minimal setup
 -------------
 

--- a/docs/howto/web/index.rst
+++ b/docs/howto/web/index.rst
@@ -24,3 +24,4 @@ The common pattern is:
    starlette
    flask
    django
+   django-modern-rest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     "typing-extensions>=4.15.0",
     "wireup>=2.7.0",
     "py-spy>=0.4.1",
+    "django-modern-rest>=0.0.0 ; python_version >= '3.11' and python_version < '3.15'",
 ]
 
 docs = [

--- a/tests/docs/test_docs_code_blocks.py
+++ b/tests/docs/test_docs_code_blocks.py
@@ -29,7 +29,16 @@ _RESOLVER_CONTEXT_IMPORT_RE = re.compile(
 )
 
 _OPTIONAL_DOC_DEPS: frozenset[str] = frozenset(
-    {"aiohttp", "celery", "django", "fastapi", "flask", "litestar", "starlette"}
+    {
+        "aiohttp",
+        "celery",
+        "django",
+        "dmr",
+        "fastapi",
+        "flask",
+        "litestar",
+        "starlette",
+    }
 )
 
 

--- a/tests/integrations/django_modern_rest/__init__.py
+++ b/tests/integrations/django_modern_rest/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for django-modern-rest support."""

--- a/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
+++ b/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
@@ -9,7 +9,7 @@ pytest.importorskip("django")
 pytest.importorskip("dmr")
 pytest.importorskip("pydantic")
 
-from django.http import HttpRequest, HttpResponseBase
+from django.http import HttpRequest, HttpResponse
 from django.test import override_settings
 from django.urls import path
 from dmr import Controller
@@ -24,7 +24,7 @@ from tests._django_setup import ensure_django_setup
 ensure_django_setup()
 
 
-def _json_body(response: HttpResponseBase) -> dict[str, str]:
+def _json_body(response: HttpResponse) -> dict[str, str]:
     content = cast("bytes", response.content)
     return cast("dict[str, str]", loads(content))
 

--- a/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
+++ b/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
@@ -22,6 +22,7 @@ from tests._django_setup import ensure_django_setup
 
 ensure_django_setup()
 
+
 def _json_body(response: HttpResponseBase) -> dict[str, str]:
     content = cast("bytes", response.content)
     return cast("dict[str, str]", loads(content))
@@ -29,6 +30,7 @@ def _json_body(response: HttpResponseBase) -> dict[str, str]:
 
 class _PathResponse(BaseModel):
     path: str
+
 
 @dataclass
 class _RequestPathService:

--- a/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
+++ b/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
@@ -1,0 +1,86 @@
+from collections.abc import Iterator
+from dataclasses import dataclass
+from json import loads
+from typing import cast
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("django")
+pytest.importorskip("dmr")
+
+from django.http import HttpRequest, HttpResponseBase
+from django.test import override_settings
+from django.urls import path
+from dmr import Controller
+from dmr.plugins.pydantic import PydanticSerializer
+from dmr.test import DMRClient
+
+from diwire import Container, Injected, Lifetime, Scope, resolver_context
+from diwire.integrations.django import add_request_context
+from tests._django_setup import ensure_django_setup
+
+ensure_django_setup()
+
+def _json_body(response: HttpResponseBase) -> dict[str, str]:
+    content = cast("bytes", response.content)
+    return cast("dict[str, str]", loads(content))
+
+
+class _PathResponse(BaseModel):
+    path: str
+
+@dataclass
+class _RequestPathService:
+    request: HttpRequest
+
+    def path(self) -> str:
+        return self.request.path
+
+
+_container = Container()
+add_request_context(_container)
+_container.add(
+    _RequestPathService,
+    scope=Scope.REQUEST,
+    lifetime=Lifetime.SCOPED,
+)
+
+
+class _DirectRequestController(Controller[PydanticSerializer]):
+    @resolver_context.inject(scope=Scope.REQUEST)
+    def get(self, request: Injected[HttpRequest]) -> _PathResponse:
+        return _PathResponse(path=request.path)
+
+
+class _RequestServiceController(Controller[PydanticSerializer]):
+    @resolver_context.inject(scope=Scope.REQUEST)
+    def get(self, service: Injected[_RequestPathService]) -> _PathResponse:
+        return _PathResponse(path=service.path())
+
+
+urlpatterns = [
+    path("request/direct/", _DirectRequestController.as_view()),
+    path("request/service/", _RequestServiceController.as_view()),
+]
+
+
+@pytest.fixture()
+def client() -> Iterator[DMRClient]:
+    with override_settings(
+        ROOT_URLCONF=__name__,
+        MIDDLEWARE=["diwire.integrations.django.RequestContextMiddleware"],
+    ):
+        yield DMRClient()
+
+
+def test_request_resolve_for_controller_endpoint(client: DMRClient) -> None:
+    response = client.get("/request/direct/")
+    assert response.status_code == 200
+    assert _json_body(response) == {"path": "/request/direct/"}
+
+
+def test_request_resolve_in_service_for_controller_endpoint(client: DMRClient) -> None:
+    response = client.get("/request/service/")
+    assert response.status_code == 200
+    assert _json_body(response) == {"path": "/request/service/"}

--- a/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
+++ b/tests/integrations/django_modern_rest/test_django_modern_rest_integration.py
@@ -4,10 +4,10 @@ from json import loads
 from typing import cast
 
 import pytest
-from pydantic import BaseModel
 
 pytest.importorskip("django")
 pytest.importorskip("dmr")
+pytest.importorskip("pydantic")
 
 from django.http import HttpRequest, HttpResponseBase
 from django.test import override_settings
@@ -15,6 +15,7 @@ from django.urls import path
 from dmr import Controller
 from dmr.plugins.pydantic import PydanticSerializer
 from dmr.test import DMRClient
+from pydantic import BaseModel
 
 from diwire import Container, Injected, Lifetime, Scope, resolver_context
 from diwire.integrations.django import add_request_context

--- a/uv.lock
+++ b/uv.lock
@@ -617,6 +617,7 @@ dev = [
     { name = "dishka" },
     { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.15'" },
+    { name = "django-modern-rest", marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
     { name = "fastapi", marker = "python_full_version < '3.15'" },
     { name = "flask" },
     { name = "httpx" },
@@ -660,6 +661,7 @@ dev = [
     { name = "celery", extras = ["redis"], marker = "python_full_version < '3.15'", specifier = ">=5.5.3" },
     { name = "dishka", specifier = ">=1.7.2" },
     { name = "django", marker = "python_full_version < '3.15'", specifier = ">=5.2.0" },
+    { name = "django-modern-rest", marker = "python_full_version >= '3.11' and python_full_version < '3.15'", specifier = ">=0.0.0" },
     { name = "fastapi", marker = "python_full_version < '3.15'", specifier = ">=0.128.0" },
     { name = "flask", specifier = ">=3.1.2" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -725,6 +727,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/3e/a1c4207c5dea4697b7a3387e26584919ba987d8f9320f59dc0b5c557a4eb/django-6.0.2.tar.gz", hash = "sha256:3046a53b0e40d4b676c3b774c73411d7184ae2745fe8ce5e45c0f33d3ddb71a7", size = 10886874, upload-time = "2026-02-03T13:50:31.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/ba/a6e2992bc5b8c688249c00ea48cb1b7a9bc09839328c81dc603671460928/django-6.0.2-py3-none-any.whl", hash = "sha256:610dd3b13d15ec3f1e1d257caedd751db8033c5ad8ea0e2d1219a8acf446ecc6", size = 8339381, upload-time = "2026-02-03T13:50:15.501Z" },
+]
+
+[[package]]
+name = "django-modern-rest"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ea/6c5d0431d5ddab35045d0d8c6ea9d4f206b6612e7e4cebabc51f32701516/django_modern_rest-0.1.0.tar.gz", hash = "sha256:8b680753841c502925cc1dc0c334e8030291bd05935638b2c51b24590ad3045b", size = 726779, upload-time = "2026-03-13T08:33:55.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/ba/eb40c3f1b4e5316b2d5b75c4b032437046fe2abcd912816fcf8efa233d22/django_modern_rest-0.1.0-py3-none-any.whl", hash = "sha256:29833b65df15c5570b80f48fa9889f1a478cec5614085063ba68bccee60a70cf", size = 781267, upload-time = "2026-03-13T08:33:57.398Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a how-to for django-modern-rest with examples showing request-context injection, request-scoped services, and an example API endpoint returning request paths.

* **Examples**
  * Included a runnable snippet demonstrating a controller and a request-scoped service returning both direct and service-provided paths.

* **Tests**
  * Added integration and snippet tests verifying request path resolution for both direct injection and service-based patterns.

* **Chores**
  * Updated dev dependencies and test optional deps to support the new docs/examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->