### PR TITLE
fix: scope metadata rebinding on class reuse

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3457,7 +3457,7 @@ from pathlib import Path
 
 def main() -> None:
     example_dir = Path(__file__).resolve().parent
-    completed = subprocess.run(  # noqa: S603
+    completed = subprocess.run(
         [sys.executable, "-m", "pytest", "-q", "test_demo.py"],
         cwd=example_dir,
         capture_output=True,

--- a/examples/ex_14_pytest_plugin/01_pytest_plugin.py
+++ b/examples/ex_14_pytest_plugin/01_pytest_plugin.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 def main() -> None:
     example_dir = Path(__file__).resolve().parent
-    completed = subprocess.run(  # noqa: S603
+    completed = subprocess.run(
         [sys.executable, "-m", "pytest", "-q", "test_demo.py"],
         cwd=example_dir,
         capture_output=True,

--- a/src/diwire/_internal/scope.py
+++ b/src/diwire/_internal/scope.py
@@ -22,9 +22,20 @@ class BaseScope(int):
 
     def __set_name__(
         self,
-        owner: type[BaseScopes],
+        owner: type[object],
         name: str,
     ) -> None:
+        # ``BaseScope`` values are plain constants. Reusing ``Scope.REQUEST`` as a
+        # class attribute on arbitrary user classes should not rewrite the shared
+        # metadata used by resolver generation and scope traversal.
+        if not issubclass(owner, BaseScopes):
+            return
+
+        if getattr(self, "owner", None) is owner and getattr(self, "scope_name", None) == name:
+            return
+        if hasattr(self, "owner") or hasattr(self, "scope_name"):
+            return
+
         self.owner = owner
         self.scope_name = name
 

--- a/tests/unit/internal/test_container_scope_binding.py
+++ b/tests/unit/internal/test_container_scope_binding.py
@@ -5,6 +5,7 @@ from contextvars import ContextVar
 import pytest
 
 from diwire import Container, Lifetime, Scope
+from diwire._internal.scope import BaseScope, BaseScopes, Scopes
 from diwire.exceptions import DIWireScopeMismatchError
 
 
@@ -39,6 +40,53 @@ def test_container_resolve_uses_context_bound_scope_by_default() -> None:
 
     with container.enter_scope(Scope.REQUEST):
         assert isinstance(container.resolve(_RequestOnly), _RequestOnly)
+
+
+def test_plain_class_attributes_do_not_rebind_shared_scope_metadata() -> None:
+    class _ScopeHolder:
+        app_scope = Scope.APP
+        request_scope = Scope.REQUEST
+
+    assert _ScopeHolder.app_scope is Scope.APP
+    assert _ScopeHolder.request_scope is Scope.REQUEST
+    assert Scope.APP.owner is Scopes
+    assert Scope.REQUEST.owner is Scopes
+    assert Scope.APP.scope_name == "APP"
+    assert Scope.REQUEST.scope_name == "REQUEST"
+
+    container = Container()
+    container.add(
+        _RequestOnly,
+        provides=_RequestOnly,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container.enter_scope(Scope.REQUEST):
+        assert isinstance(container.resolve(_RequestOnly), _RequestOnly)
+
+
+def test_scope_metadata_binding_is_idempotent_for_the_same_owner() -> None:
+    scope = BaseScope(99)
+
+    scope.__set_name__(Scopes, "CUSTOM")
+    scope.__set_name__(Scopes, "CUSTOM")
+
+    assert scope.owner is Scopes
+    assert scope.scope_name == "CUSTOM"
+
+
+def test_scope_metadata_binding_keeps_first_base_scopes_owner() -> None:
+    class _OtherScopes(BaseScopes):
+        pass
+
+    scope = BaseScope(100)
+
+    scope.__set_name__(Scopes, "CUSTOM")
+    scope.__set_name__(_OtherScopes, "OTHER")
+
+    assert scope.owner is Scopes
+    assert scope.scope_name == "CUSTOM"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- prevent shared `BaseScope` instances from rebinding their internal metadata when reused as plain class attributes
- add regression coverage for ordinary class reuse and idempotent metadata binding
- remove a stale lint suppression in the pytest plugin example and regenerate the examples README

## Root Cause
`BaseScope` implements `__set_name__`. When a user assigned `Scope.APP` or `Scope.REQUEST` onto another class body, Python called `__set_name__` on the shared scope object again and overwrote its `owner` / `scope_name` metadata. That could corrupt scope traversal and resolver generation.

## Validation
- `make format`
- `make lint`
- `make test`
- `make test-e2e-fastapi`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope constant reuse behavior to prevent unintended metadata rebinding when scope constants are assigned as class attributes.

* **Tests**
  * Added comprehensive test coverage for scope metadata binding behavior, including idempotency verification and owner retention validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->