### PR TITLE
fix(docs): cache pyodide runner source for inspection

### DIFF
--- a/docs/sphinx-pyodide-runner/sphinx_pyodide_runner/_static/pyodide-runner.js
+++ b/docs/sphinx-pyodide-runner/sphinx_pyodide_runner/_static/pyodide-runner.js
@@ -120,6 +120,7 @@ await micropip.install([${escaped}])
       const result = await pyodide.runPythonAsync(`
 from contextlib import redirect_stdout, redirect_stderr
 from io import StringIO
+import linecache
 import sys
 import types
 
@@ -128,14 +129,22 @@ _stderr = StringIO()
 with redirect_stdout(_stdout), redirect_stderr(_stderr):
     # Execute in a real module so get_type_hints() can resolve names via sys.modules.
     _mod = types.ModuleType("__main__")
+    _filename = f"<pyodide-runner-{id(_mod)}>"
+    _source_lines = __RUN_CODE__.splitlines(keepends=True)
+    if __RUN_CODE__ and not __RUN_CODE__.endswith(("\\n", "\\r")):
+        _source_lines[-1] += "\\n"
+
+    linecache.cache[_filename] = (len(__RUN_CODE__), None, _source_lines, _filename)
     _mod.__dict__["__name__"] = "__main__"
     _mod.__dict__["__package__"] = None
+    _mod.__dict__["__file__"] = _filename
 
     _old_main = sys.modules.get("__main__")
     sys.modules["__main__"] = _mod
     try:
-        exec(__RUN_CODE__, _mod.__dict__)
+        exec(compile(__RUN_CODE__, _filename, "exec"), _mod.__dict__)
     finally:
+        linecache.cache.pop(_filename, None)
         if _old_main is None:
             del sys.modules["__main__"]
         else:

--- a/tests/docs/test_pyodide_runner_source_cache.py
+++ b/tests/docs/test_pyodide_runner_source_cache.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").is_file() and (candidate / "src" / "diwire").is_dir():
+            return candidate
+    msg = f"Could not locate repository root from {start}"
+    raise AssertionError(msg)
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+RUNNER_JS = (
+    REPO_ROOT
+    / "docs"
+    / "sphinx-pyodide-runner"
+    / "sphinx_pyodide_runner"
+    / "_static"
+    / "pyodide-runner.js"
+)
+AUTO_OPEN_SCOPE_REUSE_EXAMPLE = (
+    REPO_ROOT / "examples" / "ex_06_function_injection" / "05_auto_open_scope_reuse.py"
+)
+SINGLETON_CLEANUP_EXAMPLE = (
+    REPO_ROOT / "examples" / "ex_04_scopes_and_cleanup" / "04_singleton_cleanup.py"
+)
+_RUNNER_PYTHON_RE = re.compile(
+    r"const result = await pyodide\.runPythonAsync\(`\n(?P<code>.*?)\n`\);",
+    re.DOTALL,
+)
+
+
+def _extract_runner_python() -> str:
+    text = RUNNER_JS.read_text(encoding="utf-8")
+    match = _RUNNER_PYTHON_RE.search(text)
+    if match is None:
+        msg = "Could not find runner Python code in pyodide-runner.js"
+        raise AssertionError(msg)
+    return match.group("code")
+
+
+def _eval_last_expression(source: str, globals_dict: dict[str, Any]) -> Any:
+    module = ast.parse(source)
+    if not module.body or not isinstance(module.body[-1], ast.Expr):
+        msg = "Runner Python code must end with the result expression."
+        raise AssertionError(msg)
+
+    module.body[-1] = ast.Assign(
+        targets=[ast.Name(id="__runner_result__", ctx=ast.Store())],
+        value=module.body[-1].value,
+    )
+    ast.fix_missing_locations(module)
+    exec(compile(module, "<test-pyodide-runner>", "exec"), globals_dict)  # noqa: S102
+    return globals_dict["__runner_result__"]
+
+
+def test_pyodide_runner_caches_dynamic_source_for_inspection() -> None:
+    code = """
+import inspect
+
+
+def main() -> None:
+    def provider():
+        try:
+            yield 1
+        finally:
+            pass
+
+    print(f"source_has_finally={'finally' in inspect.getsource(provider)}")
+
+
+if __name__ == "__main__":
+    main()
+""".strip()
+
+    stdout, stderr = _eval_last_expression(
+        _extract_runner_python(),
+        {"__RUN_CODE__": code},
+    )
+
+    assert stdout == "source_has_finally=True\n"
+    assert stderr == ""
+
+
+def test_pyodide_runner_executes_auto_open_scope_reuse_example() -> None:
+    stdout, stderr = _eval_last_expression(
+        _extract_runner_python(),
+        {"__RUN_CODE__": AUTO_OPEN_SCOPE_REUSE_EXAMPLE.read_text(encoding="utf-8")},
+    )
+
+    assert stdout.splitlines() == [
+        "target_scope_reused=True",
+        "cleanup_after_outer_scope=True",
+        "deeper_scope_contextvar_reused=22",
+    ]
+    assert stderr == ""
+
+
+def test_pyodide_runner_executes_singleton_cleanup_example() -> None:
+    stdout, stderr = _eval_last_expression(
+        _extract_runner_python(),
+        {"__RUN_CODE__": SINGLETON_CLEANUP_EXAMPLE.read_text(encoding="utf-8")},
+    )
+
+    assert stdout == "singleton_cleanup_on_close=True\n"
+    assert stderr == ""


### PR DESCRIPTION
## Summary

- cache browser-runner source code in `linecache` while runnable docs examples execute
- compile dynamic runner code with a stable virtual filename so `inspect.getsource()` can find it
- add regression coverage for dynamic source inspection and the affected generator-provider examples

## Root Cause

The browser runner executes docs examples from a dynamic string. `Container.add_generator()` validates provider cleanup by using `inspect.getsource()`, but dynamically executed functions had a virtual filename without a matching `linecache` entry. That made generator-provider examples fail online even though they worked as local files.

Closes #184.

## Validation

- `uv run pytest -q tests/docs/test_pyodide_runner_source_cache.py`
- `uv run python examples/ex_04_scopes_and_cleanup/04_singleton_cleanup.py`
- `uv run python examples/ex_06_function_injection/05_auto_open_scope_reuse.py`
- `uv run ruff format --check tests/docs/test_pyodide_runner_source_cache.py`
- `uv run ruff check tests/docs/test_pyodide_runner_source_cache.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Python code execution with improved traceback information, providing better error diagnostics and source visibility when debugging dynamically executed code.

* **Tests**
  * Added comprehensive test coverage validating dynamic code execution behavior and proper resource cleanup across various execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->