### PR TITLE
fix(providers): rebind lazy handles after container mutation

### DIFF
--- a/docs/howto/examples/providers.rst
+++ b/docs/howto/examples/providers.rst
@@ -10,6 +10,7 @@ What you'll learn
 - Break dependency cycles with ``Provider[T]``.
 - Defer expensive object construction.
 - Observe scoped vs transient behavior through provider calls.
+- Use already-created provider handles after registration updates.
 
 Break cycle provider
 --------------------
@@ -50,5 +51,19 @@ Run locally
    uv run python examples/ex_20_providers/03_provider_lifetime_semantics.py
 
 .. literalinclude:: ../../../examples/ex_20_providers/03_provider_lifetime_semantics.py
+   :language: python
+   :class: diwire-example py-run
+
+Live registration updates
+-------------------------
+
+Run locally
+~~~~~~~~~~~
+
+.. code-block:: bash
+
+   uv run python examples/ex_20_providers/04_live_registration_updates.py
+
+.. literalinclude:: ../../../examples/ex_20_providers/04_live_registration_updates.py
    :language: python
    :class: diwire-example py-run

--- a/docs/howto/examples/pytest-plugin.rst
+++ b/docs/howto/examples/pytest-plugin.rst
@@ -8,6 +8,7 @@ What you'll learn
 -----------------
 
 - Enable ``diwire.integrations.pytest_plugin`` for ``Injected[T]`` test parameters.
+- Inject ``AsyncProvider[T]`` into async tests and apply per-test overrides.
 
 Run locally
 -----------
@@ -23,3 +24,6 @@ Example
    :language: python
    :class: diwire-example
 
+.. literalinclude:: ../../../examples/ex_14_pytest_plugin/test_demo.py
+   :language: python
+   :class: diwire-example

--- a/examples/README.md
+++ b/examples/README.md
@@ -1675,6 +1675,7 @@ Files:
 - [01_break_cycle_provider.py](#ex-20-providers--01-break-cycle-provider-py)
 - [02_lazy_construction_provider.py](#ex-20-providers--02-lazy-construction-provider-py)
 - [03_provider_lifetime_semantics.py](#ex-20-providers--03-provider-lifetime-semantics-py)
+- [04_live_registration_updates.py](#ex-20-providers--04-live-registration-updates-py)
 
 <a id="ex-20-providers--01-break-cycle-provider-py"></a>
 ### [01_break_cycle_provider.py](ex_20_providers/01_break_cycle_provider.py)
@@ -1819,6 +1820,52 @@ def main() -> None:
     print(f"scoped_same_identity={scoped_same}")  # => scoped_same_identity=True
     print(f"transient_after_calls={transient_calls}")  # => transient_after_calls=2
     print(f"transient_same_identity={transient_same}")  # => transient_same_identity=False
+
+
+if __name__ == "__main__":
+    main()
+```
+
+<a id="ex-20-providers--04-live-registration-updates-py"></a>
+### [04_live_registration_updates.py](ex_20_providers/04_live_registration_updates.py)
+
+Focused example: provider handles observe registration updates.
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from diwire import Container, Provider
+
+
+@dataclass(slots=True)
+class Service:
+    value: str
+
+
+class UsesServiceProvider:
+    def __init__(self, service_provider: Provider[Service]) -> None:
+        self._service_provider = service_provider
+
+    def get_service(self) -> Service:
+        return self._service_provider()
+
+
+def main() -> None:
+    container = Container()
+    container.add_instance(Service("old"), provides=Service)
+    container.add(UsesServiceProvider)
+
+    consumer = container.resolve(UsesServiceProvider)
+    direct_provider = container.resolve(Provider[Service])
+
+    container.add_instance(Service("new"), provides=Service)
+
+    print(
+        f"constructor_provider_value={consumer.get_service().value}"
+    )  # => constructor_provider_value=new
+    print(f"direct_provider_value={direct_provider().value}")  # => direct_provider_value=new
 
 
 if __name__ == "__main__":
@@ -3577,7 +3624,8 @@ Files:
 Pytest plugin integration smoke test.
 
 Runs ``pytest -q test_demo.py`` in this folder to validate
-``diwire.integrations.pytest_plugin`` with ``Injected[T]`` test parameters.
+``diwire.integrations.pytest_plugin`` with ``Injected[T]`` and
+``Injected[AsyncProvider[T]]`` test parameters.
 
 ```python
 from __future__ import annotations
@@ -3611,7 +3659,7 @@ from __future__ import annotations
 
 import pytest
 
-from diwire import Container, Injected, Lifetime
+from diwire import AsyncProvider, Container, Injected, Lifetime
 
 pytest_plugins = ["diwire.integrations.pytest_plugin"]
 
@@ -3621,6 +3669,10 @@ class Service:
 
 
 class ServiceImpl(Service):
+    pass
+
+
+class UpdatedService(Service):
     pass
 
 
@@ -3638,6 +3690,25 @@ def diwire_container() -> Container:
 def test_plugin_injects_parameters(service: Injected[Service]) -> None:
     if not isinstance(service, ServiceImpl):
         msg = "Injected service is not ServiceImpl"
+        raise TypeError(msg)
+
+
+@pytest.mark.asyncio
+async def test_async_provider_sees_test_override(
+    diwire_container: Container,
+    service_provider: Injected[AsyncProvider[Service]],
+) -> None:
+    before = await service_provider()
+
+    diwire_container.add_instance(UpdatedService(), provides=Service)
+    after = await service_provider()
+
+    if not isinstance(before, ServiceImpl):
+        msg = "Injected async provider did not use original Service"
+        raise TypeError(msg)
+
+    if not isinstance(after, UpdatedService):
+        msg = "Injected async provider did not use updated Service"
         raise TypeError(msg)
 ```
 

--- a/examples/ex_14_pytest_plugin/01_pytest_plugin.py
+++ b/examples/ex_14_pytest_plugin/01_pytest_plugin.py
@@ -1,7 +1,8 @@
 """Pytest plugin integration smoke test.
 
 Runs ``pytest -q test_demo.py`` in this folder to validate
-``diwire.integrations.pytest_plugin`` with ``Injected[T]`` test parameters.
+``diwire.integrations.pytest_plugin`` with ``Injected[T]`` and
+``Injected[AsyncProvider[T]]`` test parameters.
 """
 
 from __future__ import annotations

--- a/examples/ex_14_pytest_plugin/test_demo.py
+++ b/examples/ex_14_pytest_plugin/test_demo.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from diwire import Container, Injected, Lifetime
+from diwire import AsyncProvider, Container, Injected, Lifetime
 
 pytest_plugins = ["diwire.integrations.pytest_plugin"]
 
@@ -12,6 +12,10 @@ class Service:
 
 
 class ServiceImpl(Service):
+    pass
+
+
+class UpdatedService(Service):
     pass
 
 
@@ -29,4 +33,23 @@ def diwire_container() -> Container:
 def test_plugin_injects_parameters(service: Injected[Service]) -> None:
     if not isinstance(service, ServiceImpl):
         msg = "Injected service is not ServiceImpl"
+        raise TypeError(msg)
+
+
+@pytest.mark.asyncio
+async def test_async_provider_sees_test_override(
+    diwire_container: Container,
+    service_provider: Injected[AsyncProvider[Service]],
+) -> None:
+    before = await service_provider()
+
+    diwire_container.add_instance(UpdatedService(), provides=Service)
+    after = await service_provider()
+
+    if not isinstance(before, ServiceImpl):
+        msg = "Injected async provider did not use original Service"
+        raise TypeError(msg)
+
+    if not isinstance(after, UpdatedService):
+        msg = "Injected async provider did not use updated Service"
         raise TypeError(msg)

--- a/examples/ex_20_providers/04_live_registration_updates.py
+++ b/examples/ex_20_providers/04_live_registration_updates.py
@@ -1,0 +1,40 @@
+"""Focused example: provider handles observe registration updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from diwire import Container, Provider
+
+
+@dataclass(slots=True)
+class Service:
+    value: str
+
+
+class UsesServiceProvider:
+    def __init__(self, service_provider: Provider[Service]) -> None:
+        self._service_provider = service_provider
+
+    def get_service(self) -> Service:
+        return self._service_provider()
+
+
+def main() -> None:
+    container = Container()
+    container.add_instance(Service("old"), provides=Service)
+    container.add(UsesServiceProvider)
+
+    consumer = container.resolve(UsesServiceProvider)
+    direct_provider = container.resolve(Provider[Service])
+
+    container.add_instance(Service("new"), provides=Service)
+
+    print(
+        f"constructor_provider_value={consumer.get_service().value}"
+    )  # => constructor_provider_value=new
+    print(f"direct_provider_value={direct_provider().value}")  # => direct_provider_value=new
+
+
+if __name__ == "__main__":
+    main()

--- a/src/diwire/_internal/container.py
+++ b/src/diwire/_internal/container.py
@@ -191,6 +191,7 @@ class Container:
 
         self._root_resolver: ResolverProtocol | None = None
         self._entered_root_resolver: ResolverProtocol | None = None
+        self._stale_root_resolvers: list[ResolverProtocol] = []
         self._graph_revision: int = 0
         self._registration_mutation_depth: int = 0
         self._registration_mutation_snapshot: _ContainerGraphSnapshot | None = None
@@ -3312,6 +3313,8 @@ class Container:
                 root_resolver = self._resolvers_manager.build_root_resolver(
                     root_scope=self._root_scope,
                     registrations=self._providers_registrations,
+                    live_provider_container=self,
+                    live_provider_graph_revision=self._graph_revision,
                 )
                 if self._open_generic_registry.has_specs():
                     has_async_specs = any(
@@ -3344,6 +3347,8 @@ class Container:
         """
         with self._graph_state_lock:
             self._graph_revision += 1
+            if self._root_resolver is not None:
+                self._stale_root_resolvers.append(self._root_resolver)
             self._root_resolver = None
             self._restore_container_entrypoints()
 
@@ -3687,16 +3692,50 @@ class Container:
         Cleanup will happen ONLY if the resolver created resources that need to be cleaned up.
         Like context managers or generators.
         """
-        active_resolver = (
-            self._entered_root_resolver
-            if self._entered_root_resolver is not None
-            else self._root_resolver
-        )
-        if active_resolver is None:
+        entered_resolver = self._entered_root_resolver
+        if (
+            entered_resolver is None
+            and self._root_resolver is None
+            and not self._stale_root_resolvers
+        ):
             msg = "Container context exit called without a matching enter."
             raise RuntimeError(msg)
+        cleanup_error: BaseException | None = None
+        closed_resolver_ids: set[int] = set()
         try:
-            return active_resolver.__exit__(exc_type, exc_value, traceback)
+            if entered_resolver is not None:
+                closed_resolver_ids.add(id(entered_resolver))
+                try:
+                    entered_resolver.__exit__(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    cleanup_error = error
+
+            while self._stale_root_resolvers:
+                stale_resolver = self._stale_root_resolvers.pop(0)
+                if id(stale_resolver) in closed_resolver_ids:
+                    continue
+                closed_resolver_ids.add(id(stale_resolver))
+                try:
+                    stale_resolver.close(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    if cleanup_error is None:
+                        cleanup_error = error
+
+            while self._root_resolver is not None:
+                current_resolver = self._root_resolver
+                if id(current_resolver) in closed_resolver_ids:
+                    break
+                if not _container_resolver_is_active(current_resolver):
+                    break
+                closed_resolver_ids.add(id(current_resolver))
+                try:
+                    current_resolver.close(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    if cleanup_error is None:
+                        cleanup_error = error
+
+            if cleanup_error is not None:
+                raise cleanup_error
         finally:
             self._entered_root_resolver = None
 
@@ -3717,16 +3756,50 @@ class Container:
         Cleanup will happen ONLY if the resolver created resources that need to be cleaned up.
         Like context managers or generators.
         """
-        active_resolver = (
-            self._entered_root_resolver
-            if self._entered_root_resolver is not None
-            else self._root_resolver
-        )
-        if active_resolver is None:
+        entered_resolver = self._entered_root_resolver
+        if (
+            entered_resolver is None
+            and self._root_resolver is None
+            and not self._stale_root_resolvers
+        ):
             msg = "Container async context exit called without a matching enter."
             raise RuntimeError(msg)
+        cleanup_error: BaseException | None = None
+        closed_resolver_ids: set[int] = set()
         try:
-            return await active_resolver.__aexit__(exc_type, exc_value, traceback)
+            if entered_resolver is not None:
+                closed_resolver_ids.add(id(entered_resolver))
+                try:
+                    await entered_resolver.__aexit__(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    cleanup_error = error
+
+            while self._stale_root_resolvers:
+                stale_resolver = self._stale_root_resolvers.pop(0)
+                if id(stale_resolver) in closed_resolver_ids:
+                    continue
+                closed_resolver_ids.add(id(stale_resolver))
+                try:
+                    await stale_resolver.aclose(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    if cleanup_error is None:
+                        cleanup_error = error
+
+            while self._root_resolver is not None:
+                current_resolver = self._root_resolver
+                if id(current_resolver) in closed_resolver_ids:
+                    break
+                if not _container_resolver_is_active(current_resolver):
+                    break
+                closed_resolver_ids.add(id(current_resolver))
+                try:
+                    await current_resolver.aclose(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    if cleanup_error is None:
+                        cleanup_error = error
+
+            if cleanup_error is not None:
+                raise cleanup_error
         finally:
             self._entered_root_resolver = None
 
@@ -3778,6 +3851,21 @@ class Container:
         return await self.__aexit__(exc_type, exc_value, traceback)
 
     # endregion Resolution and Scope Management
+
+
+def _container_resolver_is_active(resolver: Any) -> bool:
+    try:
+        wrapped_resolver = object.__getattribute__(resolver, "_resolver")
+    except AttributeError:
+        wrapped_resolver = resolver
+    try:
+        base_resolver = object.__getattribute__(wrapped_resolver, "_base_resolver")
+    except AttributeError:
+        base_resolver = wrapped_resolver
+    try:
+        return bool(object.__getattribute__(base_resolver, "_active"))
+    except AttributeError:
+        return True
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/diwire/_internal/open_generics.py
+++ b/src/diwire/_internal/open_generics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import inspect
 import logging
 import threading
@@ -48,6 +49,9 @@ _MAYBE_UNHANDLED = object()
 _UNSET_CACHE = object()
 logger = logging.getLogger(__name__)
 _MISSING_TYPEVAR_DEFAULT = object()
+_LIVE_PROVIDER_CLEANUP_RESOLVER_IDS: contextvars.ContextVar[frozenset[int]] = (
+    contextvars.ContextVar("_OPEN_GENERIC_LIVE_PROVIDER_CLEANUP_RESOLVER_IDS", default=frozenset())
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -354,6 +358,14 @@ class _OpenGenericResolver:  # pragma: no cover
         "_cleanup_callbacks",
         "_cleanup_enabled",
         "_has_async_specs",
+        "_live_provider_closing",
+        "_live_provider_condition",
+        "_live_provider_container",
+        "_live_provider_epoch",
+        "_live_provider_graph_revision",
+        "_live_provider_inflight",
+        "_live_provider_lock",
+        "_live_provider_scope_cache",
         "_local_state_lock",
         "_managed_scopes",
         "_materialization_attempt_lock",
@@ -411,6 +423,10 @@ class _OpenGenericResolver:  # pragma: no cover
             getattr(base_resolver, "_cleanup_enabled", True),
         )
         self._owned_scope_wrappers: tuple[_OpenGenericResolver, ...] = ()
+        self._init_live_provider_state(
+            base_resolver=base_resolver,
+            root_wrapper=root_wrapper,
+        )
         if root_wrapper is None:
             self._managed_scopes = tuple(
                 sorted(
@@ -476,6 +492,37 @@ class _OpenGenericResolver:  # pragma: no cover
             materialize_closed_callback=materialize_closed_callback,
         )
 
+    def _init_live_provider_state(
+        self,
+        *,
+        base_resolver: ResolverProtocol,
+        root_wrapper: _OpenGenericResolver | None,
+    ) -> None:
+        self._live_provider_scope_cache: dict[tuple[int, int], Any] = {}
+        self._live_provider_lock = threading.RLock()
+        self._live_provider_condition = threading.Condition(self._live_provider_lock)
+        self._live_provider_closing = False
+        self._live_provider_inflight = 0
+        self._live_provider_epoch = _resolver_live_provider_epoch(resolver=base_resolver)
+        if root_wrapper is None:
+            base_runtime = getattr(type(base_resolver), "_runtime", None)
+            self._live_provider_container = getattr(
+                base_runtime,
+                "live_provider_container",
+                None,
+            )
+            self._live_provider_graph_revision = getattr(
+                base_runtime,
+                "live_provider_graph_revision",
+                None,
+            )
+            return
+
+        (
+            self._live_provider_container,
+            self._live_provider_graph_revision,
+        ) = root_wrapper.live_provider_metadata()
+
     def _init_runtime_resolver_state(
         self,
         *,
@@ -513,6 +560,9 @@ class _OpenGenericResolver:  # pragma: no cover
         set[Any],
     ]:
         return self._shared_child_state
+
+    def live_provider_metadata(self) -> tuple[Any | None, int | None]:
+        return self._live_provider_container, self._live_provider_graph_revision
 
     def _refresh_shared_child_state(self) -> None:
         self._shared_child_state = (
@@ -799,47 +849,53 @@ class _OpenGenericResolver:  # pragma: no cover
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        if not self._owned_scope_wrappers and not self._cleanup_callbacks:
-            self._base_resolver.__exit__(exc_type, exc_value, traceback)
-            return
+        self._begin_live_provider_close()
+        cleanup_token = _enter_live_provider_cleanup_context(resolver=self)
+        cleanup_error: BaseException | None = None
+        try:
+            try:
+                if not self._owned_scope_wrappers and not self._cleanup_callbacks:
+                    self._base_resolver.__exit__(exc_type, exc_value, traceback)
+                else:
+                    callbacks: list[tuple[int, Any]] = (
+                        self._cleanup_callbacks
+                        if self._resolver_cleanup_callbacks() is None
+                        else []
+                    )
 
-        callbacks: list[tuple[int, Any]] = (
-            self._cleanup_callbacks if self._resolver_cleanup_callbacks() is None else []
-        )
-
-        def _base_exit_callback(
-            callback_exc_type: type[BaseException] | None,
-            callback_exc_value: BaseException | None,
-            callback_traceback: TracebackType | None,
-        ) -> None:
-            self._base_resolver.__exit__(
-                callback_exc_type,
-                callback_exc_value,
-                callback_traceback,
-            )
-
-        if self._owned_scope_wrappers:
-            callbacks[:0] = [
-                (
-                    0,
-                    lambda callback_exc_type, callback_exc_value, callback_traceback, owned_scope_wrapper=owned_scope_wrapper: (
-                        owned_scope_wrapper.__exit__(
+                    def _base_exit_callback(
+                        callback_exc_type: type[BaseException] | None,
+                        callback_exc_value: BaseException | None,
+                        callback_traceback: TracebackType | None,
+                    ) -> None:
+                        self._base_resolver.__exit__(
                             callback_exc_type,
                             callback_exc_value,
                             callback_traceback,
                         )
-                    ),
-                )
-                for owned_scope_wrapper in self._owned_scope_wrappers
-            ]
 
-        callbacks.append((0, _base_exit_callback))
-        _execute_sync_cleanup_callbacks(
-            callbacks=callbacks,
-            exc_type=exc_type,
-            exc_value=exc_value,
-            traceback=traceback,
-        )
+                    callbacks.insert(0, (0, _base_exit_callback))
+                    _execute_sync_cleanup_callbacks(
+                        callbacks=callbacks,
+                        exc_type=exc_type,
+                        exc_value=exc_value,
+                        traceback=traceback,
+                    )
+            except BaseException as error:  # noqa: BLE001
+                cleanup_error = error
+            cleanup_error = self._close_owned_live_provider_rebounds_sync(
+                exc_type=exc_type,
+                exc_value=exc_value,
+                traceback=traceback,
+                cleanup_error=cleanup_error,
+            )
+            if cleanup_error is not None:
+                raise cleanup_error
+        finally:
+            try:
+                self._clear_live_provider_rebounds()
+            finally:
+                _leave_live_provider_cleanup_context(token=cleanup_token)
 
     def close(
         self,
@@ -861,47 +917,53 @@ class _OpenGenericResolver:  # pragma: no cover
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        if not self._owned_scope_wrappers and not self._cleanup_callbacks:
-            await self._base_resolver.__aexit__(exc_type, exc_value, traceback)
-            return
+        await self._begin_live_provider_aclose()
+        cleanup_token = _enter_live_provider_cleanup_context(resolver=self)
+        cleanup_error: BaseException | None = None
+        try:
+            try:
+                if not self._owned_scope_wrappers and not self._cleanup_callbacks:
+                    await self._base_resolver.__aexit__(exc_type, exc_value, traceback)
+                else:
+                    callbacks: list[tuple[int, Any]] = (
+                        self._cleanup_callbacks
+                        if self._resolver_cleanup_callbacks() is None
+                        else []
+                    )
 
-        callbacks: list[tuple[int, Any]] = (
-            self._cleanup_callbacks if self._resolver_cleanup_callbacks() is None else []
-        )
-
-        async def _base_aexit_callback(
-            callback_exc_type: type[BaseException] | None,
-            callback_exc_value: BaseException | None,
-            callback_traceback: TracebackType | None,
-        ) -> None:
-            await self._base_resolver.__aexit__(
-                callback_exc_type,
-                callback_exc_value,
-                callback_traceback,
-            )
-
-        if self._owned_scope_wrappers:
-            callbacks[:0] = [
-                (
-                    1,
-                    lambda callback_exc_type, callback_exc_value, callback_traceback, owned_scope_wrapper=owned_scope_wrapper: (
-                        owned_scope_wrapper.__aexit__(
+                    async def _base_aexit_callback(
+                        callback_exc_type: type[BaseException] | None,
+                        callback_exc_value: BaseException | None,
+                        callback_traceback: TracebackType | None,
+                    ) -> None:
+                        await self._base_resolver.__aexit__(
                             callback_exc_type,
                             callback_exc_value,
                             callback_traceback,
                         )
-                    ),
-                )
-                for owned_scope_wrapper in self._owned_scope_wrappers
-            ]
 
-        callbacks.append((1, _base_aexit_callback))
-        await _execute_async_cleanup_callbacks(
-            callbacks=callbacks,
-            exc_type=exc_type,
-            exc_value=exc_value,
-            traceback=traceback,
-        )
+                    callbacks.insert(0, (1, _base_aexit_callback))
+                    await _execute_async_cleanup_callbacks(
+                        callbacks=callbacks,
+                        exc_type=exc_type,
+                        exc_value=exc_value,
+                        traceback=traceback,
+                    )
+            except BaseException as error:  # noqa: BLE001
+                cleanup_error = error
+            cleanup_error = await self._close_owned_live_provider_rebounds_async(
+                exc_type=exc_type,
+                exc_value=exc_value,
+                traceback=traceback,
+                cleanup_error=cleanup_error,
+            )
+            if cleanup_error is not None:
+                raise cleanup_error
+        finally:
+            try:
+                self._clear_live_provider_rebounds()
+            finally:
+                _leave_live_provider_cleanup_context(token=cleanup_token)
 
     async def aclose(
         self,
@@ -910,6 +972,99 @@ class _OpenGenericResolver:  # pragma: no cover
         traceback: TracebackType | None = None,
     ) -> None:
         return await self.__aexit__(exc_type, exc_value, traceback)
+
+    def _begin_live_provider_close(self) -> None:
+        with self._live_provider_condition:
+            self._live_provider_closing = True
+            while self._live_provider_inflight:
+                self._live_provider_condition.wait()
+
+    async def _begin_live_provider_aclose(self) -> None:
+        while True:
+            with self._live_provider_lock:
+                self._live_provider_closing = True
+                if not self._live_provider_inflight:
+                    return
+            await asyncio.sleep(0.001)
+
+    def _clear_live_provider_rebounds(self) -> None:
+        with self._live_provider_lock:
+            self._owned_scope_wrappers = ()
+            self._live_provider_scope_cache.clear()
+
+    def _close_owned_live_provider_rebounds_sync(
+        self,
+        *,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        cleanup_error: BaseException | None,
+    ) -> BaseException | None:
+        while self._owned_scope_wrappers:
+            owned_scope_wrappers = self._owned_scope_wrappers
+            self._owned_scope_wrappers = ()
+            for owned_scope_wrapper in reversed(owned_scope_wrappers):
+                cleanup_error = self._close_owned_live_provider_rebound_sync(
+                    owned_scope_wrapper=owned_scope_wrapper,
+                    exc_type=exc_type,
+                    exc_value=exc_value,
+                    traceback=traceback,
+                    cleanup_error=cleanup_error,
+                )
+        return cleanup_error
+
+    def _close_owned_live_provider_rebound_sync(
+        self,
+        *,
+        owned_scope_wrapper: _OpenGenericResolver,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        cleanup_error: BaseException | None,
+    ) -> BaseException | None:
+        try:
+            owned_scope_wrapper.__exit__(exc_type, exc_value, traceback)
+        except BaseException as error:  # noqa: BLE001
+            if exc_type is None and cleanup_error is None:
+                cleanup_error = error
+        return cleanup_error
+
+    async def _close_owned_live_provider_rebounds_async(
+        self,
+        *,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        cleanup_error: BaseException | None,
+    ) -> BaseException | None:
+        while self._owned_scope_wrappers:
+            owned_scope_wrappers = self._owned_scope_wrappers
+            self._owned_scope_wrappers = ()
+            for owned_scope_wrapper in reversed(owned_scope_wrappers):
+                cleanup_error = await self._close_owned_live_provider_rebound_async(
+                    owned_scope_wrapper=owned_scope_wrapper,
+                    exc_type=exc_type,
+                    exc_value=exc_value,
+                    traceback=traceback,
+                    cleanup_error=cleanup_error,
+                )
+        return cleanup_error
+
+    async def _close_owned_live_provider_rebound_async(
+        self,
+        *,
+        owned_scope_wrapper: _OpenGenericResolver,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        cleanup_error: BaseException | None,
+    ) -> BaseException | None:
+        try:
+            await owned_scope_wrapper.__aexit__(exc_type, exc_value, traceback)
+        except BaseException as error:  # noqa: BLE001
+            if exc_type is None and cleanup_error is None:
+                cleanup_error = error
+        return cleanup_error
 
     def _resolve_open_match_sync(
         self,
@@ -1672,10 +1827,10 @@ class _OpenGenericResolver:  # pragma: no cover
         if not is_provider_annotation(dependency):
             return _MISSING_CACHE
         inner_dependency = strip_provider_annotation(dependency)
-        provider_factory = (
-            self.aresolve if is_async_provider_annotation(dependency) else self.resolve
+        return self._live_provider_handle(
+            dependency=inner_dependency,
+            is_async=is_async_provider_annotation(dependency),
         )
-        return lambda: provider_factory(inner_dependency)
 
     async def _resolve_async_annotation_preflight(self, *, dependency: Any) -> Any:
         maybe_value = await self._resolve_maybe_async(dependency=dependency)
@@ -1684,10 +1839,227 @@ class _OpenGenericResolver:  # pragma: no cover
         if not is_provider_annotation(dependency):
             return _MISSING_CACHE
         inner_dependency = strip_provider_annotation(dependency)
-        provider_factory = (
-            self.aresolve if is_async_provider_annotation(dependency) else self.resolve
+        return self._live_provider_handle(
+            dependency=inner_dependency,
+            is_async=is_async_provider_annotation(dependency),
         )
-        return lambda: provider_factory(inner_dependency)
+
+    def _live_provider_handle(self, *, dependency: Any, is_async: bool) -> Callable[[], Any]:
+        match = self._registry.find_best_match(dependency)
+        requires_same_revision_guard = match is None or match.spec.needs_cleanup
+        if is_async:
+            return self._async_live_provider_handle(
+                dependency=dependency,
+                requires_same_revision_guard=requires_same_revision_guard,
+            )
+        return self._sync_live_provider_handle(
+            dependency=dependency,
+            requires_same_revision_guard=requires_same_revision_guard,
+        )
+
+    def _async_live_provider_handle(
+        self,
+        *,
+        dependency: Any,
+        requires_same_revision_guard: bool,
+    ) -> Callable[[], Any]:
+        async_fast_resolver = self.aresolve
+        container = self._live_provider_container
+        compiled_graph_revision = self._live_provider_graph_revision
+        if container is None or compiled_graph_revision is None:
+            return lambda: async_fast_resolver(dependency)
+
+        async def _async_provider() -> Any:
+            current_graph_revision = getattr(container, "_graph_revision", compiled_graph_revision)
+            if (
+                current_graph_revision == compiled_graph_revision
+                and not requires_same_revision_guard
+            ):
+                return await async_fast_resolver(dependency)
+            provider_call_started = self._begin_original_live_provider_call(
+                current_graph_revision=current_graph_revision,
+                compiled_graph_revision=compiled_graph_revision,
+            )
+            try:
+                if current_graph_revision == compiled_graph_revision:
+                    return await async_fast_resolver(dependency)
+                target_resolver = self._stale_live_provider_target_resolver(
+                    current_graph_revision=current_graph_revision,
+                    expected_scope_epoch=self._live_provider_epoch,
+                )
+                target_call_started = _resolver_begin_live_provider_call(
+                    resolver=target_resolver,
+                )
+                try:
+                    return await target_resolver.aresolve(dependency)
+                finally:
+                    _resolver_end_live_provider_call(
+                        resolver=target_resolver,
+                        started=target_call_started,
+                    )
+            finally:
+                self._end_live_provider_call(started=provider_call_started)
+
+        return _async_provider
+
+    def _sync_live_provider_handle(
+        self,
+        *,
+        dependency: Any,
+        requires_same_revision_guard: bool,
+    ) -> Callable[[], Any]:
+        sync_fast_resolver = self.resolve
+        container = self._live_provider_container
+        compiled_graph_revision = self._live_provider_graph_revision
+        if container is None or compiled_graph_revision is None:
+            return lambda: sync_fast_resolver(dependency)
+
+        def _sync_provider() -> Any:
+            current_graph_revision = getattr(container, "_graph_revision", compiled_graph_revision)
+            if (
+                current_graph_revision == compiled_graph_revision
+                and not requires_same_revision_guard
+            ):
+                return sync_fast_resolver(dependency)
+            provider_call_started = self._begin_original_live_provider_call(
+                current_graph_revision=current_graph_revision,
+                compiled_graph_revision=compiled_graph_revision,
+            )
+            try:
+                if current_graph_revision == compiled_graph_revision:
+                    return sync_fast_resolver(dependency)
+                target_resolver = self._stale_live_provider_target_resolver(
+                    current_graph_revision=current_graph_revision,
+                    expected_scope_epoch=self._live_provider_epoch,
+                )
+                target_call_started = _resolver_begin_live_provider_call(
+                    resolver=target_resolver,
+                )
+                try:
+                    return target_resolver.resolve(dependency)
+                finally:
+                    _resolver_end_live_provider_call(
+                        resolver=target_resolver,
+                        started=target_call_started,
+                    )
+            finally:
+                self._end_live_provider_call(started=provider_call_started)
+
+        return _sync_provider
+
+    def _begin_original_live_provider_call(
+        self,
+        *,
+        current_graph_revision: int,
+        compiled_graph_revision: int,
+    ) -> bool:
+        if (
+            self._scope_level == self._root_scope.level
+            and current_graph_revision != compiled_graph_revision
+            and _in_live_provider_cleanup_context(resolver=self)
+        ):
+            return False
+        return self._begin_live_provider_call(expected_scope_epoch=self._live_provider_epoch)
+
+    def _stale_live_provider_target_resolver(
+        self,
+        *,
+        current_graph_revision: int,
+        expected_scope_epoch: int,
+    ) -> Any:
+        container = self._live_provider_container
+        if container is None:
+            return self
+
+        if self._scope_level == self._root_scope.level:
+            return self._live_provider_rebound_root_resolver(
+                graph_revision=current_graph_revision,
+                expected_scope_epoch=expected_scope_epoch,
+            )
+
+        cache_key = (current_graph_revision, self._scope_level)
+        with self._live_provider_lock:
+            self._raise_if_live_provider_scope_closed(
+                expected_scope_epoch=expected_scope_epoch,
+                allow_closing=True,
+            )
+
+            cached_resolver = self._live_provider_scope_cache.get(cache_key)
+            if cached_resolver is not None:
+                return cached_resolver
+
+            target_scope = self._live_provider_scope_by_level(scope_level=self._scope_level)
+            latest_root_resolver = _latest_container_base_resolver(container=container)
+            rebound_resolver = latest_root_resolver.enter_scope(target_scope)
+            self._live_provider_scope_cache[cache_key] = rebound_resolver
+            owned_scope_wrappers = cast("tuple[Any, ...]", self._owned_scope_wrappers)
+            self._owned_scope_wrappers = cast(
+                "tuple[_OpenGenericResolver, ...]",
+                (*owned_scope_wrappers, latest_root_resolver, rebound_resolver),
+            )
+            return rebound_resolver
+
+    def _live_provider_rebound_root_resolver(
+        self,
+        *,
+        graph_revision: int,
+        expected_scope_epoch: int,
+    ) -> Any:
+        container = self._live_provider_container
+        if container is None:
+            return self
+
+        cache_key = (graph_revision, self._scope_level)
+        with self._live_provider_lock:
+            self._raise_if_live_provider_scope_closed(
+                expected_scope_epoch=expected_scope_epoch,
+                allow_closing=True,
+            )
+
+            cached_resolver = self._live_provider_scope_cache.get(cache_key)
+            if cached_resolver is not None:
+                return cached_resolver
+
+            rebound_resolver = _latest_container_base_resolver(container=container)
+            self._live_provider_scope_cache[cache_key] = rebound_resolver
+            owned_scope_wrappers = cast("tuple[Any, ...]", self._owned_scope_wrappers)
+            self._owned_scope_wrappers = cast(
+                "tuple[_OpenGenericResolver, ...]",
+                (*owned_scope_wrappers, rebound_resolver),
+            )
+            return rebound_resolver
+
+    def _live_provider_scope_by_level(self, *, scope_level: int) -> BaseScope:
+        return next(scope for scope in self._managed_scopes if scope.level == scope_level)
+
+    def _begin_live_provider_call(self, *, expected_scope_epoch: int) -> bool:
+        with self._live_provider_lock:
+            self._raise_if_live_provider_scope_closed(
+                expected_scope_epoch=expected_scope_epoch,
+            )
+            self._live_provider_inflight += 1
+            return True
+
+    def _end_live_provider_call(self, *, started: bool) -> None:
+        if not started:
+            return
+
+        with self._live_provider_condition:
+            self._live_provider_inflight -= 1
+            self._live_provider_condition.notify_all()
+
+    def _raise_if_live_provider_scope_closed(
+        self,
+        *,
+        expected_scope_epoch: int,
+        allow_closing: bool = False,
+    ) -> None:
+        if (
+            (self._live_provider_closing and not allow_closing)
+            or not getattr(self._base_resolver, "_active", True)
+            or _resolver_live_provider_epoch(resolver=self._base_resolver) != expected_scope_epoch
+        ):
+            _raise_closed_live_provider_scope(scope_level=self._scope_level)
 
     @staticmethod
     def _missing_sync_inline_resolver() -> NoReturn:
@@ -1768,6 +2140,115 @@ def cast_mapping(value: Any) -> Mapping[str, Any]:
         return value
     msg = f"Expected mapping value for variadic keyword dependency, got {value!r}."
     raise TypeError(msg)
+
+
+def _enter_live_provider_cleanup_context(
+    *,
+    resolver: Any,
+) -> contextvars.Token[frozenset[int]]:
+    cleanup_resolver_ids = _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.get()
+    return _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.set(
+        cleanup_resolver_ids | frozenset((id(resolver),)),
+    )
+
+
+def _leave_live_provider_cleanup_context(
+    *,
+    token: contextvars.Token[frozenset[int]],
+) -> None:
+    _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.reset(token)
+
+
+def _in_live_provider_cleanup_context(*, resolver: Any) -> bool:
+    return id(resolver) in _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.get()
+
+
+def _latest_container_base_resolver(*, container: Any) -> Any:
+    resolver = container.compile()
+    return getattr(resolver, "_resolver", resolver)
+
+
+def _resolver_live_provider_epoch(*, resolver: Any) -> int:
+    return cast("int", getattr(resolver, "_live_provider_epoch", 0))
+
+
+def _resolver_live_provider_scope_level(*, resolver: Any) -> int | None:
+    if isinstance(resolver, _OpenGenericResolver):
+        return cast("int", object.__getattribute__(resolver, "_scope_level"))
+
+    runtime = getattr(type(resolver), "_runtime", None)
+    if runtime is None:
+        return None
+    root_scope_level = getattr(runtime, "root_scope_level", None)
+    if root_scope_level is None:
+        return None
+    class_plan = getattr(type(resolver), "_class_plan", None)
+    return cast("int", getattr(class_plan, "scope_level", root_scope_level))
+
+
+def _resolver_begin_live_provider_call(*, resolver: Any) -> bool:
+    scope_level = _resolver_live_provider_scope_level(resolver=resolver)
+    if scope_level is None:
+        return False
+
+    live_provider_lock = getattr(resolver, "_live_provider_lock", None)
+    if live_provider_lock is None:
+        _resolver_raise_if_live_provider_scope_closed(
+            resolver=resolver,
+            scope_level=scope_level,
+        )
+        return False
+
+    with live_provider_lock:
+        _resolver_raise_if_live_provider_scope_closed(
+            resolver=resolver,
+            scope_level=scope_level,
+        )
+        object.__setattr__(
+            resolver,
+            "_live_provider_inflight",
+            getattr(resolver, "_live_provider_inflight", 0) + 1,
+        )
+        return True
+
+
+def _resolver_end_live_provider_call(*, resolver: Any, started: bool) -> None:
+    if not started:
+        return
+
+    live_provider_condition = getattr(resolver, "_live_provider_condition", None)
+    if live_provider_condition is None:
+        return
+    with live_provider_condition:
+        object.__setattr__(
+            resolver,
+            "_live_provider_inflight",
+            getattr(resolver, "_live_provider_inflight", 0) - 1,
+        )
+        live_provider_condition.notify_all()
+
+
+def _resolver_raise_if_live_provider_scope_closed(
+    *,
+    resolver: Any,
+    scope_level: int,
+) -> None:
+    active_resolver = getattr(resolver, "_base_resolver", resolver)
+    default_active = active_resolver is not resolver
+    if not getattr(active_resolver, "_active", default_active) or getattr(
+        resolver,
+        "_live_provider_closing",
+        False,
+    ):
+        _raise_closed_live_provider_scope(scope_level=scope_level)
+
+
+def _raise_closed_live_provider_scope(*, scope_level: int) -> NoReturn:
+    msg = (
+        f"Provider handle created in scope level {scope_level} cannot resolve against "
+        "a newer container graph after that scope has closed or started closing."
+    )
+    raise DIWireScopeMismatchError(msg)
 
 
 def _build_binding_plan(

--- a/src/diwire/_internal/resolvers/assembly/compiler.py
+++ b/src/diwire/_internal/resolvers/assembly/compiler.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-# ruff: noqa: C901,FBT001,PERF203,PERF401,PLR0911,PLR0912,PLR0913,PLW0108,SLF001
+# ruff: noqa: C901,FBT001,PERF203,PERF401,PLR0911,PLR0912,PLR0913,SLF001
 import ast
 import asyncio
+import contextvars
 import inspect
 import keyword
 import logging
@@ -12,7 +13,7 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from types import CodeType, TracebackType
-from typing import Any, Final, Literal, cast
+from typing import Any, Final, Literal, NoReturn, cast
 
 from diwire._internal.injection import INJECT_RESOLVER_KWARG
 from diwire._internal.lock_mode import LockMode
@@ -56,6 +57,10 @@ _DISPATCH_CACHE_WORKFLOW_THRESHOLD: Final[int] = 4
 _CLEANUP_KIND_SYNC: Final[int] = 0
 _CLEANUP_KIND_ASYNC: Final[int] = 1
 _CLEANUP_KIND_SYNC_GENERATOR: Final[int] = 2
+_LIVE_PROVIDER_CLEANUP_RESOLVER_IDS: contextvars.ContextVar[frozenset[int]] = (
+    contextvars.ContextVar("_LIVE_PROVIDER_CLEANUP_RESOLVER_IDS", default=frozenset())
+)
+_LIVE_PROVIDER_STATE_INIT_LOCK: Final[threading.Lock] = threading.Lock()
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +85,7 @@ class _ResolverRuntime:
     has_cleanup: bool
     dep_registered_keys: set[Any]
     all_slots_by_key: dict[Any, tuple[int, ...]]
+    dep_slot_by_key: dict[Any, int]
     dep_eq_slot_by_key: dict[Any, int]
     dep_type_by_slot: dict[int, Any]
     provider_by_slot: dict[int, Any]
@@ -89,6 +95,8 @@ class _ResolverRuntime:
     next_scope_options_by_level: dict[
         int, tuple[ScopePlan | None, ScopePlan | None, tuple[ScopePlan, ...]]
     ]
+    live_provider_container: Any | None = None
+    live_provider_graph_revision: int | None = None
 
 
 class ResolversAssemblyCompiler:
@@ -100,6 +108,8 @@ class ResolversAssemblyCompiler:
         root_scope: BaseScope,
         registrations: ProvidersRegistrations,
         cleanup_enabled: bool = True,
+        live_provider_container: Any | None = None,
+        live_provider_graph_revision: int | None = None,
     ) -> ResolverProtocol:
         plan = ResolverGenerationPlanner(
             root_scope=root_scope,
@@ -111,6 +121,8 @@ class ResolversAssemblyCompiler:
             plan=plan,
             registrations=registrations,
             root_scope=root_scope,
+            live_provider_container=live_provider_container,
+            live_provider_graph_revision=live_provider_graph_revision,
         )
         generated_globals = self._build_generated_globals(runtime=runtime)
 
@@ -153,6 +165,8 @@ class ResolversAssemblyCompiler:
         plan: ResolverGenerationPlan,
         registrations: ProvidersRegistrations,
         root_scope: BaseScope,
+        live_provider_container: Any | None = None,
+        live_provider_graph_revision: int | None = None,
     ) -> _ResolverRuntime:
         ordered_scopes = tuple(sorted(plan.scopes, key=lambda scope: scope.scope_level))
         scopes_by_level = {scope.scope_level: scope for scope in ordered_scopes}
@@ -161,6 +175,7 @@ class ResolversAssemblyCompiler:
 
         dep_registered_keys: set[Any] = set()
         all_slots_by_key_mut: dict[Any, list[int]] = {}
+        dep_slot_by_key: dict[Any, int] = {}
         dep_eq_slot_by_key: dict[Any, int] = {}
         dep_type_by_slot: dict[int, Any] = {}
         provider_by_slot: dict[int, Any] = {}
@@ -169,6 +184,7 @@ class ResolversAssemblyCompiler:
             registration = registrations.get_by_slot(workflow.slot)
             dep_type = registration.provides
             dep_type_by_slot[workflow.slot] = dep_type
+            dep_slot_by_key[dep_type] = workflow.slot
             provider_by_slot[workflow.slot] = getattr(registration, workflow.provider_attribute)
             dep_registered_keys.add(dep_type)
 
@@ -226,7 +242,7 @@ class ResolversAssemblyCompiler:
                 deeper_scopes,
             )
 
-        uses_stateless_scope_reuse = not any(
+        uses_stateless_scope_reuse = live_provider_container is None and not any(
             workflow.scope_level > plan.root_scope_level for workflow in plan.workflows
         )
         scope_obj_by_level = {
@@ -249,6 +265,7 @@ class ResolversAssemblyCompiler:
             has_cleanup=plan.has_cleanup,
             dep_registered_keys=dep_registered_keys,
             all_slots_by_key=all_slots_by_key,
+            dep_slot_by_key=dep_slot_by_key,
             dep_eq_slot_by_key=dep_eq_slot_by_key,
             dep_type_by_slot=dep_type_by_slot,
             provider_by_slot=provider_by_slot,
@@ -256,6 +273,8 @@ class ResolversAssemblyCompiler:
             async_lock_by_slot=async_lock_by_slot,
             cache_slots_by_owner_level=cache_slots_by_owner_level,
             next_scope_options_by_level=next_scope_options_by_level,
+            live_provider_container=live_provider_container,
+            live_provider_graph_revision=live_provider_graph_revision,
         )
 
     def _build_generated_globals(self, *, runtime: _ResolverRuntime) -> dict[str, Any]:
@@ -266,10 +285,28 @@ class ResolversAssemblyCompiler:
             "_MISSING_CACHE": _MISSING_CACHE,
             "_MISSING_DEP_SLOT": _MISSING_DEP_SLOT,
             "_resolver_init": _resolver_init,
+            "_resolver_init_live_provider_state": _resolver_init_live_provider_state,
+            "_resolver_reset_live_provider_state": _resolver_reset_live_provider_state,
+            "_resolver_begin_live_provider_close": _resolver_begin_live_provider_close,
+            "_resolver_begin_live_provider_aclose": _resolver_begin_live_provider_aclose,
+            "_resolver_clear_live_provider_rebounds": _resolver_clear_live_provider_rebounds,
+            "_resolver_close_owned_scope_resolvers_sync": (
+                _resolver_close_owned_scope_resolvers_sync
+            ),
+            "_resolver_close_owned_scope_resolvers_async": (
+                _resolver_close_owned_scope_resolvers_async
+            ),
+            "_resolver_enter_live_provider_cleanup_context": (
+                _resolver_enter_live_provider_cleanup_context
+            ),
+            "_resolver_leave_live_provider_cleanup_context": (
+                _resolver_leave_live_provider_cleanup_context
+            ),
             "_resolver_enter_scope": _resolver_enter_scope,
             "_resolver_is_registered_dependency": _resolver_is_registered_dependency,
             "_resolver_exit": _resolver_exit,
             "_resolver_aexit": _resolver_aexit,
+            "_live_provider_handle": _live_provider_handle,
             "_resolve_dispatch_fallback_sync": _resolve_dispatch_fallback_sync,
             "_resolve_dispatch_fallback_async": _resolve_dispatch_fallback_async,
             "_dep_eq_slot_by_key": runtime.dep_eq_slot_by_key,
@@ -431,6 +468,12 @@ class ResolversAssemblyCompiler:
         slots: list[str] = [
             "_root_resolver",
             "_owned_scope_resolvers",
+            "_live_provider_scope_cache",
+            "_live_provider_lock",
+            "_live_provider_condition",
+            "_live_provider_closing",
+            "_live_provider_inflight",
+            "_live_provider_epoch",
             "_active",
         ]
         if _dispatch_cache_enabled_for_class(plan=runtime.plan, class_plan=class_plan):
@@ -593,6 +636,7 @@ class ResolversAssemblyCompiler:
         body_lines: list[str] = [
             f"self._root_resolver = {'self' if class_plan.is_root else 'root_resolver'}",
             "self._owned_scope_resolvers = ()",
+            "_resolver_init_live_provider_state(self)",
             "self._active = True",
         ]
         if enable_dispatch_cache:
@@ -769,7 +813,7 @@ class ResolversAssemblyCompiler:
             pooled_lines = [
                 f"_pooled = self._scope_resolver_{target_level}",
                 "if not _pooled._active:",
-                "    _pooled._owned_scope_resolvers = ()",
+                "    _resolver_reset_live_provider_state(_pooled)",
             ]
             if runtime.has_cleanup:
                 pooled_lines.extend(
@@ -1155,21 +1199,6 @@ class ResolversAssemblyCompiler:
                 name=name,
                 arg_names=("self", "exc_type", "exc_value", "traceback"),
                 body_lines=[
-                    "if exc_type is None and not self._owned_scope_resolvers and not self._cleanup_callbacks:",
-                    "    single_cleanup = self._cleanup_callback_single",
-                    "    if single_cleanup is not None:",
-                    "        try:",
-                    "            single_cleanup.close()",
-                    "        finally:",
-                    "            self._cleanup_callback_single = None",
-                    "            self._active = False",
-                    "        return None",
-                    "if self._cleanup_callback_single is not None:",
-                    "    single_cleanup = self._cleanup_callback_single",
-                    "    try:",
-                    "        self._cleanup_callbacks.append((2, single_cleanup))",
-                    "    finally:",
-                    "        self._cleanup_callback_single = None",
                     "return _resolver_exit(self, exc_type, exc_value, traceback)",
                 ],
                 generated_globals=generated_globals,
@@ -1231,22 +1260,46 @@ class ResolversAssemblyCompiler:
 
         if is_async:
             body_lines = [
-                "if not self._owned_scope_resolvers:",
+                "if not self._owned_scope_resolvers and self._live_provider_condition is None:",
                 "    self._active = False",
                 "    return None",
-                "for owned_scope_resolver in reversed(self._owned_scope_resolvers):",
-                "    await owned_scope_resolver.__aexit__(exc_type, exc_value, traceback)",
-                "self._active = False",
+                "await _resolver_begin_live_provider_aclose(self)",
+                "_cleanup_token = _resolver_enter_live_provider_cleanup_context(resolver=self)",
+                "_cleanup_error = None",
+                "try:",
+                "    _cleanup_error = await _resolver_close_owned_scope_resolvers_async(",
+                "        self=self,",
+                "        exc_type=exc_type,",
+                "        exc_value=exc_value,",
+                "        traceback=traceback,",
+                "        cleanup_error=_cleanup_error,",
+                "    )",
+                "finally:",
+                "    _resolver_leave_live_provider_cleanup_context(token=_cleanup_token)",
+                "if exc_type is None and _cleanup_error is not None:",
+                "    raise _cleanup_error",
                 "return None",
             ]
         else:
             body_lines = [
-                "if not self._owned_scope_resolvers:",
+                "if not self._owned_scope_resolvers and self._live_provider_condition is None:",
                 "    self._active = False",
                 "    return None",
-                "for owned_scope_resolver in reversed(self._owned_scope_resolvers):",
-                "    owned_scope_resolver.__exit__(exc_type, exc_value, traceback)",
-                "self._active = False",
+                "_resolver_begin_live_provider_close(self)",
+                "_cleanup_token = _resolver_enter_live_provider_cleanup_context(resolver=self)",
+                "_cleanup_error = None",
+                "try:",
+                "    _cleanup_error = _resolver_close_owned_scope_resolvers_sync(",
+                "        self=self,",
+                "        exc_type=exc_type,",
+                "        exc_value=exc_value,",
+                "        traceback=traceback,",
+                "        cleanup_error=_cleanup_error,",
+                "    )",
+                "finally:",
+                "    _resolver_leave_live_provider_cleanup_context(token=_cleanup_token)",
+                "if exc_type is None and _cleanup_error is not None:",
+                "    raise _cleanup_error",
                 "return None",
             ]
 
@@ -1649,10 +1702,11 @@ class ResolversAssemblyCompiler:
             provider_inner_slot = dependency_plan.provider_inner_slot
             if provider_inner_slot is None:
                 return _FALLBACK_ARGUMENT_EXPRESSION
+            dependency_global_name = f"_dep_{provider_inner_slot}_type"
             return (
-                f"lambda: self.aresolve_{provider_inner_slot}()"
-                if dependency_plan.provider_is_async
-                else f"lambda: self.resolve_{provider_inner_slot}()"
+                "_live_provider_handle("
+                f"self, {dependency_global_name}, {provider_inner_slot}, "
+                f"{dependency_plan.provider_is_async!r})"
             )
         if dependency_plan.kind == "all":
             slots = dependency_plan.all_slots
@@ -1835,6 +1889,7 @@ def _resolver_init(
         self._cleanup_callbacks = []
         self._cleanup_callback_single = None
     self._owned_scope_resolvers = ()
+    _resolver_init_live_provider_state(self)
     parent_scope_level = (
         _resolver_scope_level(parent_resolver) if parent_resolver is not None else None
     )
@@ -2146,6 +2201,7 @@ async def _execute_async_cleanup_callback(
 
 
 def _execute_fast_single_cleanup_sync(*, self: Any, single_cleanup: Any) -> None:
+    cleanup_error: BaseException | None = None
     try:
         if isinstance(single_cleanup, tuple):
             cleanup_kind, cleanup = single_cleanup
@@ -2155,17 +2211,28 @@ def _execute_fast_single_cleanup_sync(*, self: Any, single_cleanup: Any) -> None
                 cleanup.close()
             elif cleanup_kind == _CLEANUP_KIND_ASYNC:
                 msg = "Cannot execute async cleanup in sync context. Use 'async with'."
-                raise DIWireAsyncDependencyInSyncContextError(msg)
+                cleanup_error = DIWireAsyncDependencyInSyncContextError(msg)
             else:
                 cleanup.close()
         else:
             single_cleanup.close()
+    except BaseException as error:  # noqa: BLE001
+        cleanup_error = error
     finally:
         self._cleanup_callback_single = None
-        self._active = False
+        cleanup_error = _resolver_close_owned_scope_resolvers_sync(
+            self=self,
+            exc_type=None,
+            exc_value=None,
+            traceback=None,
+            cleanup_error=cleanup_error,
+        )
+    if cleanup_error is not None:
+        raise cleanup_error
 
 
 def _execute_fast_single_callback_sync(*, self: Any, cleanup_kind: int, cleanup: Any) -> None:
+    cleanup_error: BaseException | None = None
     try:
         if cleanup_kind == _CLEANUP_KIND_SYNC:
             cleanup(None, None, None)
@@ -2173,12 +2240,23 @@ def _execute_fast_single_callback_sync(*, self: Any, cleanup_kind: int, cleanup:
             cleanup.close()
         else:
             msg = "Cannot execute async cleanup in sync context. Use 'async with'."
-            raise DIWireAsyncDependencyInSyncContextError(msg)
+            cleanup_error = DIWireAsyncDependencyInSyncContextError(msg)
+    except BaseException as error:  # noqa: BLE001
+        cleanup_error = error
     finally:
-        self._active = False
+        cleanup_error = _resolver_close_owned_scope_resolvers_sync(
+            self=self,
+            exc_type=None,
+            exc_value=None,
+            traceback=None,
+            cleanup_error=cleanup_error,
+        )
+    if cleanup_error is not None:
+        raise cleanup_error
 
 
 async def _execute_fast_single_cleanup_async(*, self: Any, single_cleanup: Any) -> None:
+    cleanup_error: BaseException | None = None
     try:
         if isinstance(single_cleanup, tuple):
             cleanup_kind, cleanup = single_cleanup
@@ -2190,9 +2268,19 @@ async def _execute_fast_single_cleanup_async(*, self: Any, single_cleanup: Any) 
                 cleanup.close()
         else:
             single_cleanup.close()
+    except BaseException as error:  # noqa: BLE001
+        cleanup_error = error
     finally:
         self._cleanup_callback_single = None
-        self._active = False
+        cleanup_error = await _resolver_close_owned_scope_resolvers_async(
+            self=self,
+            exc_type=None,
+            exc_value=None,
+            traceback=None,
+            cleanup_error=cleanup_error,
+        )
+    if cleanup_error is not None:
+        raise cleanup_error
 
 
 async def _execute_fast_single_callback_async(
@@ -2201,6 +2289,7 @@ async def _execute_fast_single_callback_async(
     cleanup_kind: int,
     cleanup: Any,
 ) -> None:
+    cleanup_error: BaseException | None = None
     try:
         if cleanup_kind == _CLEANUP_KIND_SYNC:
             cleanup(None, None, None)
@@ -2208,8 +2297,172 @@ async def _execute_fast_single_callback_async(
             await cleanup(None, None, None)
         else:
             cleanup.close()
+    except BaseException as error:  # noqa: BLE001
+        cleanup_error = error
     finally:
+        cleanup_error = await _resolver_close_owned_scope_resolvers_async(
+            self=self,
+            exc_type=None,
+            exc_value=None,
+            traceback=None,
+            cleanup_error=cleanup_error,
+        )
+    if cleanup_error is not None:
+        raise cleanup_error
+
+
+def _resolver_enter_live_provider_cleanup_context(
+    *,
+    resolver: Any,
+) -> contextvars.Token[frozenset[int]]:
+    cleanup_resolver_ids = _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.get()
+    return _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.set(
+        cleanup_resolver_ids | frozenset((id(resolver),)),
+    )
+
+
+def _resolver_leave_live_provider_cleanup_context(
+    *,
+    token: contextvars.Token[frozenset[int]],
+) -> None:
+    _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.reset(token)
+
+
+def _resolver_in_live_provider_cleanup_context(*, resolver: Any) -> bool:
+    return id(resolver) in _LIVE_PROVIDER_CLEANUP_RESOLVER_IDS.get()
+
+
+def _resolver_init_live_provider_state(self: Any) -> None:
+    self._live_provider_scope_cache = None
+    self._live_provider_lock = None
+    self._live_provider_condition = None
+    self._live_provider_closing = False
+    self._live_provider_inflight = 0
+    self._live_provider_epoch = 0
+
+
+def _resolver_reset_live_provider_state(self: Any) -> None:
+    self._owned_scope_resolvers = ()
+    self._live_provider_scope_cache = None
+    self._live_provider_lock = None
+    self._live_provider_condition = None
+    self._live_provider_closing = False
+    self._live_provider_inflight = 0
+    self._live_provider_epoch = getattr(self, "_live_provider_epoch", 0) + 1
+
+
+def _resolver_ensure_live_provider_state(self: Any) -> None:
+    if (
+        getattr(self, "_live_provider_lock", None) is not None
+        and getattr(self, "_live_provider_scope_cache", None) is not None
+    ):
+        return
+
+    with _LIVE_PROVIDER_STATE_INIT_LOCK:
+        live_provider_lock = getattr(self, "_live_provider_lock", None)
+        if live_provider_lock is None:
+            live_provider_lock = threading.RLock()
+            self._live_provider_lock = live_provider_lock
+            self._live_provider_condition = threading.Condition(live_provider_lock)
+        if getattr(self, "_live_provider_scope_cache", None) is None:
+            self._live_provider_scope_cache = {}
+        if getattr(self, "_live_provider_inflight", None) is None:
+            self._live_provider_inflight = 0
+        if getattr(self, "_live_provider_closing", None) is None:
+            self._live_provider_closing = False
+
+
+def _resolver_begin_live_provider_close(self: Any) -> None:
+    live_provider_condition = getattr(self, "_live_provider_condition", None)
+    if live_provider_condition is None:
+        return
+    with live_provider_condition:
+        self._live_provider_closing = True
+        while self._live_provider_inflight:
+            live_provider_condition.wait()
+
+
+async def _resolver_begin_live_provider_aclose(self: Any) -> None:
+    live_provider_lock = getattr(self, "_live_provider_lock", None)
+    if live_provider_lock is None:
+        return
+    while True:
+        with live_provider_lock:
+            self._live_provider_closing = True
+            if not self._live_provider_inflight:
+                return
+        await asyncio.sleep(0.001)
+
+
+def _resolver_clear_live_provider_rebounds(self: Any) -> None:
+    live_provider_lock = getattr(self, "_live_provider_lock", None)
+    if live_provider_lock is not None:
+        with live_provider_lock:
+            self._owned_scope_resolvers = ()
+            self._live_provider_scope_cache = None
+        return
+
+    self._owned_scope_resolvers = ()
+    self._live_provider_scope_cache = None
+
+
+def _resolver_close_owned_scope_resolvers_sync(
+    *,
+    self: Any,
+    exc_type: type[BaseException] | None,
+    exc_value: BaseException | None,
+    traceback: TracebackType | None,
+    cleanup_error: BaseException | None,
+) -> BaseException | None:
+    try:
+        while True:
+            owned_scope_resolvers = _resolver_owned_scope_resolvers(self)
+            if not owned_scope_resolvers:
+                break
+            self._owned_scope_resolvers = ()
+            for owned_scope_resolver in reversed(owned_scope_resolvers):
+                try:
+                    owned_scope_resolver.__exit__(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    if exc_type is None and cleanup_error is None:
+                        cleanup_error = error
+    finally:
+        _resolver_clear_live_provider_rebounds(self)
         self._active = False
+    return cleanup_error
+
+
+async def _resolver_close_owned_scope_resolvers_async(
+    *,
+    self: Any,
+    exc_type: type[BaseException] | None,
+    exc_value: BaseException | None,
+    traceback: TracebackType | None,
+    cleanup_error: BaseException | None,
+) -> BaseException | None:
+    try:
+        while True:
+            owned_scope_resolvers = _resolver_owned_scope_resolvers(self)
+            if not owned_scope_resolvers:
+                break
+            self._owned_scope_resolvers = ()
+            for owned_scope_resolver in reversed(owned_scope_resolvers):
+                try:
+                    await owned_scope_resolver.__aexit__(exc_type, exc_value, traceback)
+                except BaseException as error:  # noqa: BLE001
+                    if exc_type is None and cleanup_error is None:
+                        cleanup_error = error
+    finally:
+        _resolver_clear_live_provider_rebounds(self)
+        self._active = False
+    return cleanup_error
+
+
+def _resolver_owned_scope_resolvers(self: Any) -> tuple[Any, ...]:
+    try:
+        return cast("tuple[Any, ...]", object.__getattribute__(self, "_owned_scope_resolvers"))
+    except AttributeError:
+        return ()
 
 
 def _resolver_exit(
@@ -2218,84 +2471,19 @@ def _resolver_exit(
     exc_value: BaseException | None,
     traceback: TracebackType | None,
 ) -> None:
-    cleanup_callbacks = self._cleanup_callbacks
-    single_cleanup = getattr(self, "_cleanup_callback_single", None)
-    owned_scope_resolvers = self._owned_scope_resolvers
-
-    if (
-        exc_type is None
-        and not owned_scope_resolvers
-        and single_cleanup is not None
-        and not cleanup_callbacks
-    ):
-        _execute_fast_single_cleanup_sync(
-            self=self,
-            single_cleanup=single_cleanup,
-        )
-        return
-
-    if single_cleanup is not None:
-        if isinstance(single_cleanup, tuple):
-            cleanup_callbacks.append(single_cleanup)
-        else:
-            cleanup_callbacks.append((_CLEANUP_KIND_SYNC_GENERATOR, single_cleanup))
-        self._cleanup_callback_single = None
-
-    cleanup_error: BaseException | None = None
-    if exc_type is None and not owned_scope_resolvers and len(cleanup_callbacks) == 1:
-        cleanup_kind, cleanup = cleanup_callbacks.pop()
-        _execute_fast_single_callback_sync(
-            self=self,
-            cleanup_kind=cleanup_kind,
-            cleanup=cleanup,
-        )
-        return
-
-    while cleanup_callbacks:
-        cleanup_kind, cleanup = cleanup_callbacks.pop()
-        try:
-            _execute_sync_cleanup_callback(
-                cleanup_kind=cleanup_kind,
-                cleanup=cleanup,
-                exc_type=exc_type,
-                exc_value=exc_value,
-                traceback=traceback,
-            )
-        except BaseException as error:  # noqa: BLE001
-            if exc_type is None and cleanup_error is None:
-                cleanup_error = error
-
-    if owned_scope_resolvers:
-        for owned_scope_resolver in reversed(owned_scope_resolvers):
-            try:
-                owned_scope_resolver.__exit__(exc_type, exc_value, traceback)
-            except BaseException as error:  # noqa: BLE001
-                if exc_type is None and cleanup_error is None:
-                    cleanup_error = error
-
-    self._active = False
-    if exc_type is None and cleanup_error is not None:
-        raise cleanup_error
-
-
-def _resolver_aexit(
-    self: Any,
-    exc_type: type[BaseException] | None,
-    exc_value: BaseException | None,
-    traceback: TracebackType | None,
-) -> Awaitable[None]:
-    async def _run() -> None:
+    _resolver_begin_live_provider_close(self)
+    cleanup_token = _resolver_enter_live_provider_cleanup_context(resolver=self)
+    try:
         cleanup_callbacks = self._cleanup_callbacks
         single_cleanup = getattr(self, "_cleanup_callback_single", None)
-        owned_scope_resolvers = self._owned_scope_resolvers
 
         if (
             exc_type is None
-            and not owned_scope_resolvers
+            and not self._owned_scope_resolvers
             and single_cleanup is not None
             and not cleanup_callbacks
         ):
-            await _execute_fast_single_cleanup_async(
+            _execute_fast_single_cleanup_sync(
                 self=self,
                 single_cleanup=single_cleanup,
             )
@@ -2309,9 +2497,9 @@ def _resolver_aexit(
             self._cleanup_callback_single = None
 
         cleanup_error: BaseException | None = None
-        if exc_type is None and not owned_scope_resolvers and len(cleanup_callbacks) == 1:
+        if exc_type is None and not self._owned_scope_resolvers and len(cleanup_callbacks) == 1:
             cleanup_kind, cleanup = cleanup_callbacks.pop()
-            await _execute_fast_single_callback_async(
+            _execute_fast_single_callback_sync(
                 self=self,
                 cleanup_kind=cleanup_kind,
                 cleanup=cleanup,
@@ -2321,7 +2509,7 @@ def _resolver_aexit(
         while cleanup_callbacks:
             cleanup_kind, cleanup = cleanup_callbacks.pop()
             try:
-                await _execute_async_cleanup_callback(
+                _execute_sync_cleanup_callback(
                     cleanup_kind=cleanup_kind,
                     cleanup=cleanup,
                     exc_type=exc_type,
@@ -2332,19 +2520,779 @@ def _resolver_aexit(
                 if exc_type is None and cleanup_error is None:
                     cleanup_error = error
 
-        if owned_scope_resolvers:
-            for owned_scope_resolver in reversed(owned_scope_resolvers):
+        cleanup_error = _resolver_close_owned_scope_resolvers_sync(
+            self=self,
+            exc_type=exc_type,
+            exc_value=exc_value,
+            traceback=traceback,
+            cleanup_error=cleanup_error,
+        )
+        if exc_type is None and cleanup_error is not None:
+            raise cleanup_error
+    finally:
+        _resolver_leave_live_provider_cleanup_context(token=cleanup_token)
+
+
+def _resolver_aexit(
+    self: Any,
+    exc_type: type[BaseException] | None,
+    exc_value: BaseException | None,
+    traceback: TracebackType | None,
+) -> Awaitable[None]:
+    async def _run() -> None:
+        await _resolver_begin_live_provider_aclose(self)
+        cleanup_token = _resolver_enter_live_provider_cleanup_context(resolver=self)
+        try:
+            cleanup_callbacks = self._cleanup_callbacks
+            single_cleanup = getattr(self, "_cleanup_callback_single", None)
+
+            if (
+                exc_type is None
+                and not self._owned_scope_resolvers
+                and single_cleanup is not None
+                and not cleanup_callbacks
+            ):
+                await _execute_fast_single_cleanup_async(
+                    self=self,
+                    single_cleanup=single_cleanup,
+                )
+                return
+
+            if single_cleanup is not None:
+                if isinstance(single_cleanup, tuple):
+                    cleanup_callbacks.append(single_cleanup)
+                else:
+                    cleanup_callbacks.append((_CLEANUP_KIND_SYNC_GENERATOR, single_cleanup))
+                self._cleanup_callback_single = None
+
+            cleanup_error: BaseException | None = None
+            if exc_type is None and not self._owned_scope_resolvers and len(cleanup_callbacks) == 1:
+                cleanup_kind, cleanup = cleanup_callbacks.pop()
+                await _execute_fast_single_callback_async(
+                    self=self,
+                    cleanup_kind=cleanup_kind,
+                    cleanup=cleanup,
+                )
+                return
+
+            while cleanup_callbacks:
+                cleanup_kind, cleanup = cleanup_callbacks.pop()
                 try:
-                    await owned_scope_resolver.__aexit__(exc_type, exc_value, traceback)
+                    await _execute_async_cleanup_callback(
+                        cleanup_kind=cleanup_kind,
+                        cleanup=cleanup,
+                        exc_type=exc_type,
+                        exc_value=exc_value,
+                        traceback=traceback,
+                    )
                 except BaseException as error:  # noqa: BLE001
                     if exc_type is None and cleanup_error is None:
                         cleanup_error = error
 
-        self._active = False
-        if exc_type is None and cleanup_error is not None:
-            raise cleanup_error
+            cleanup_error = await _resolver_close_owned_scope_resolvers_async(
+                self=self,
+                exc_type=exc_type,
+                exc_value=exc_value,
+                traceback=traceback,
+                cleanup_error=cleanup_error,
+            )
+            if exc_type is None and cleanup_error is not None:
+                raise cleanup_error
+        finally:
+            _resolver_leave_live_provider_cleanup_context(token=cleanup_token)
 
     return _run()
+
+
+def _live_provider_handle(
+    resolver: Any,
+    dependency: Any,
+    provider_slot: int | None,
+    is_async: bool,
+) -> Callable[[], Any]:
+    runtime = getattr(type(resolver), "_runtime", None)
+    container = getattr(runtime, "live_provider_container", None)
+    compiled_graph_revision = getattr(runtime, "live_provider_graph_revision", None)
+    expected_scope_epoch = _resolver_live_provider_epoch(resolver=resolver)
+    provider_scope_level = _resolver_live_provider_scope_level(
+        resolver=resolver,
+        runtime=runtime,
+    )
+    provider_is_root_scope = (
+        runtime is not None
+        and provider_scope_level is not None
+        and provider_scope_level == runtime.root_scope_level
+    )
+    requires_same_revision_guard = _live_provider_requires_same_revision_guard(
+        runtime=runtime,
+        provider_slot=provider_slot,
+        dependency=dependency,
+    )
+
+    if is_async:
+        return _async_live_provider_handle(
+            resolver=resolver,
+            runtime=runtime,
+            container=container,
+            compiled_graph_revision=compiled_graph_revision,
+            dependency=dependency,
+            provider_slot=provider_slot,
+            expected_scope_epoch=expected_scope_epoch,
+            provider_scope_level=provider_scope_level,
+            provider_is_root_scope=provider_is_root_scope,
+            requires_same_revision_guard=requires_same_revision_guard,
+        )
+    return _sync_live_provider_handle(
+        resolver=resolver,
+        runtime=runtime,
+        container=container,
+        compiled_graph_revision=compiled_graph_revision,
+        dependency=dependency,
+        provider_slot=provider_slot,
+        expected_scope_epoch=expected_scope_epoch,
+        provider_scope_level=provider_scope_level,
+        provider_is_root_scope=provider_is_root_scope,
+        requires_same_revision_guard=requires_same_revision_guard,
+    )
+
+
+def _async_live_provider_handle(
+    *,
+    resolver: Any,
+    runtime: _ResolverRuntime | None,
+    container: Any | None,
+    compiled_graph_revision: int | None,
+    dependency: Any,
+    provider_slot: int | None,
+    expected_scope_epoch: int,
+    provider_scope_level: int | None,
+    provider_is_root_scope: bool,
+    requires_same_revision_guard: bool,
+) -> Callable[[], Any]:
+    if provider_slot is None:
+        async_fast_resolver = resolver.aresolve
+        if container is None or runtime is None or compiled_graph_revision is None:
+
+            def _snapshot_async_dispatch_handle(
+                _async_fast_resolver: Callable[[Any], Awaitable[Any]] = async_fast_resolver,
+                _dependency: Any = dependency,
+            ) -> Awaitable[Any]:
+                return _async_fast_resolver(_dependency)
+
+            return _snapshot_async_dispatch_handle
+        return _guarded_async_dispatch_live_provider_handle(
+            container=container,
+            compiled_graph_revision=compiled_graph_revision,
+            dependency=dependency,
+            resolver=resolver,
+            runtime=runtime,
+            expected_scope_epoch=expected_scope_epoch,
+            provider_scope_level=provider_scope_level,
+            provider_is_root_scope=provider_is_root_scope,
+            requires_same_revision_guard=requires_same_revision_guard,
+            fast_resolver=async_fast_resolver,
+        )
+
+    async_fast_slot = getattr(resolver, f"aresolve_{provider_slot}")
+    if container is None or runtime is None or compiled_graph_revision is None:
+        return async_fast_slot
+    return _guarded_async_live_provider_handle(
+        container=container,
+        compiled_graph_revision=compiled_graph_revision,
+        dependency=dependency,
+        resolver=resolver,
+        runtime=runtime,
+        expected_scope_epoch=expected_scope_epoch,
+        provider_scope_level=provider_scope_level,
+        provider_is_root_scope=provider_is_root_scope,
+        requires_same_revision_guard=requires_same_revision_guard,
+        fast_call=async_fast_slot,
+    )
+
+
+def _guarded_async_dispatch_live_provider_handle(
+    *,
+    container: Any,
+    compiled_graph_revision: int,
+    dependency: Any,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    expected_scope_epoch: int,
+    provider_scope_level: int | None,
+    provider_is_root_scope: bool,
+    requires_same_revision_guard: bool,
+    fast_resolver: Callable[[Any], Awaitable[Any]],
+) -> Callable[[], Awaitable[Any]]:
+    async def _async_dispatch_handle(
+        _container: Any = container,
+        _compiled_graph_revision: int = compiled_graph_revision,
+        _fast_resolver: Callable[[Any], Awaitable[Any]] = fast_resolver,
+        _dependency: Any = dependency,
+        _resolver: Any = resolver,
+        _runtime: _ResolverRuntime = runtime,
+        _expected_scope_epoch: int = expected_scope_epoch,
+        _provider_scope_level: int | None = provider_scope_level,
+        _provider_is_root_scope: bool = provider_is_root_scope,
+        _requires_same_revision_guard: bool = requires_same_revision_guard,
+    ) -> Any:
+        current_graph_revision = _container._graph_revision
+        if current_graph_revision == _compiled_graph_revision and not _requires_same_revision_guard:
+            return await _fast_resolver(_dependency)
+        provider_call_started = _resolver_begin_guarded_live_provider_call(
+            resolver=_resolver,
+            scope_level=_provider_scope_level,
+            expected_scope_epoch=_expected_scope_epoch,
+            provider_is_root_scope=_provider_is_root_scope,
+            current_graph_revision=current_graph_revision,
+            compiled_graph_revision=_compiled_graph_revision,
+        )
+        try:
+            if current_graph_revision == _compiled_graph_revision:
+                return await _fast_resolver(_dependency)
+            return await _resolve_stale_live_provider_async(
+                resolver=_resolver,
+                runtime=_runtime,
+                container=_container,
+                current_graph_revision=current_graph_revision,
+                dependency=_dependency,
+                expected_scope_epoch=_expected_scope_epoch,
+            )
+        finally:
+            _resolver_end_live_provider_call(
+                resolver=_resolver,
+                started=provider_call_started,
+            )
+
+    return _async_dispatch_handle
+
+
+def _guarded_async_live_provider_handle(
+    *,
+    container: Any,
+    compiled_graph_revision: int,
+    dependency: Any,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    expected_scope_epoch: int,
+    provider_scope_level: int | None,
+    provider_is_root_scope: bool,
+    requires_same_revision_guard: bool,
+    fast_call: Callable[[], Awaitable[Any]],
+) -> Callable[[], Awaitable[Any]]:
+    async def _async_handle(
+        _container: Any = container,
+        _compiled_graph_revision: int = compiled_graph_revision,
+        _fast_call: Callable[[], Awaitable[Any]] = fast_call,
+        _dependency: Any = dependency,
+        _resolver: Any = resolver,
+        _runtime: _ResolverRuntime = runtime,
+        _expected_scope_epoch: int = expected_scope_epoch,
+        _provider_scope_level: int | None = provider_scope_level,
+        _provider_is_root_scope: bool = provider_is_root_scope,
+        _requires_same_revision_guard: bool = requires_same_revision_guard,
+    ) -> Any:
+        current_graph_revision = _container._graph_revision
+        if current_graph_revision == _compiled_graph_revision and not _requires_same_revision_guard:
+            return await _fast_call()
+        provider_call_started = _resolver_begin_guarded_live_provider_call(
+            resolver=_resolver,
+            scope_level=_provider_scope_level,
+            expected_scope_epoch=_expected_scope_epoch,
+            provider_is_root_scope=_provider_is_root_scope,
+            current_graph_revision=current_graph_revision,
+            compiled_graph_revision=_compiled_graph_revision,
+        )
+        try:
+            if current_graph_revision == _compiled_graph_revision:
+                return await _fast_call()
+            return await _resolve_stale_live_provider_async(
+                resolver=_resolver,
+                runtime=_runtime,
+                container=_container,
+                current_graph_revision=current_graph_revision,
+                dependency=_dependency,
+                expected_scope_epoch=_expected_scope_epoch,
+            )
+        finally:
+            _resolver_end_live_provider_call(
+                resolver=_resolver,
+                started=provider_call_started,
+            )
+
+    return _async_handle
+
+
+def _sync_live_provider_handle(
+    *,
+    resolver: Any,
+    runtime: _ResolverRuntime | None,
+    container: Any | None,
+    compiled_graph_revision: int | None,
+    dependency: Any,
+    provider_slot: int | None,
+    expected_scope_epoch: int,
+    provider_scope_level: int | None,
+    provider_is_root_scope: bool,
+    requires_same_revision_guard: bool,
+) -> Callable[[], Any]:
+    if provider_slot is None:
+        sync_fast_resolver = resolver.resolve
+        if container is None or runtime is None or compiled_graph_revision is None:
+
+            def _snapshot_sync_dispatch_handle(
+                _sync_fast_resolver: Callable[[Any], Any] = sync_fast_resolver,
+                _dependency: Any = dependency,
+            ) -> Any:
+                return _sync_fast_resolver(_dependency)
+
+            return _snapshot_sync_dispatch_handle
+        return _guarded_sync_dispatch_live_provider_handle(
+            container=container,
+            compiled_graph_revision=compiled_graph_revision,
+            dependency=dependency,
+            resolver=resolver,
+            runtime=runtime,
+            expected_scope_epoch=expected_scope_epoch,
+            provider_scope_level=provider_scope_level,
+            provider_is_root_scope=provider_is_root_scope,
+            requires_same_revision_guard=requires_same_revision_guard,
+            fast_resolver=sync_fast_resolver,
+        )
+
+    sync_fast_slot = getattr(resolver, f"resolve_{provider_slot}")
+    if container is None or runtime is None or compiled_graph_revision is None:
+        return sync_fast_slot
+    return _guarded_sync_live_provider_handle(
+        container=container,
+        compiled_graph_revision=compiled_graph_revision,
+        dependency=dependency,
+        resolver=resolver,
+        runtime=runtime,
+        expected_scope_epoch=expected_scope_epoch,
+        provider_scope_level=provider_scope_level,
+        provider_is_root_scope=provider_is_root_scope,
+        requires_same_revision_guard=requires_same_revision_guard,
+        fast_call=sync_fast_slot,
+    )
+
+
+def _guarded_sync_dispatch_live_provider_handle(
+    *,
+    container: Any,
+    compiled_graph_revision: int,
+    dependency: Any,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    expected_scope_epoch: int,
+    provider_scope_level: int | None,
+    provider_is_root_scope: bool,
+    requires_same_revision_guard: bool,
+    fast_resolver: Callable[[Any], Any],
+) -> Callable[[], Any]:
+    def _sync_dispatch_handle(
+        _container: Any = container,
+        _compiled_graph_revision: int = compiled_graph_revision,
+        _fast_resolver: Callable[[Any], Any] = fast_resolver,
+        _dependency: Any = dependency,
+        _resolver: Any = resolver,
+        _runtime: _ResolverRuntime = runtime,
+        _expected_scope_epoch: int = expected_scope_epoch,
+        _provider_scope_level: int | None = provider_scope_level,
+        _provider_is_root_scope: bool = provider_is_root_scope,
+        _requires_same_revision_guard: bool = requires_same_revision_guard,
+    ) -> Any:
+        current_graph_revision = _container._graph_revision
+        if current_graph_revision == _compiled_graph_revision and not _requires_same_revision_guard:
+            return _fast_resolver(_dependency)
+        provider_call_started = _resolver_begin_guarded_live_provider_call(
+            resolver=_resolver,
+            scope_level=_provider_scope_level,
+            expected_scope_epoch=_expected_scope_epoch,
+            provider_is_root_scope=_provider_is_root_scope,
+            current_graph_revision=current_graph_revision,
+            compiled_graph_revision=_compiled_graph_revision,
+        )
+        try:
+            if current_graph_revision == _compiled_graph_revision:
+                return _fast_resolver(_dependency)
+            return _resolve_stale_live_provider_sync(
+                resolver=_resolver,
+                runtime=_runtime,
+                container=_container,
+                current_graph_revision=current_graph_revision,
+                dependency=_dependency,
+                expected_scope_epoch=_expected_scope_epoch,
+            )
+        finally:
+            _resolver_end_live_provider_call(
+                resolver=_resolver,
+                started=provider_call_started,
+            )
+
+    return _sync_dispatch_handle
+
+
+def _guarded_sync_live_provider_handle(
+    *,
+    container: Any,
+    compiled_graph_revision: int,
+    dependency: Any,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    expected_scope_epoch: int,
+    provider_scope_level: int | None,
+    provider_is_root_scope: bool,
+    requires_same_revision_guard: bool,
+    fast_call: Callable[[], Any],
+) -> Callable[[], Any]:
+    def _sync_handle(
+        _container: Any = container,
+        _compiled_graph_revision: int = compiled_graph_revision,
+        _fast_call: Callable[[], Any] = fast_call,
+        _dependency: Any = dependency,
+        _resolver: Any = resolver,
+        _runtime: _ResolverRuntime = runtime,
+        _expected_scope_epoch: int = expected_scope_epoch,
+        _provider_scope_level: int | None = provider_scope_level,
+        _provider_is_root_scope: bool = provider_is_root_scope,
+        _requires_same_revision_guard: bool = requires_same_revision_guard,
+    ) -> Any:
+        current_graph_revision = _container._graph_revision
+        if current_graph_revision == _compiled_graph_revision and not _requires_same_revision_guard:
+            return _fast_call()
+        provider_call_started = _resolver_begin_guarded_live_provider_call(
+            resolver=_resolver,
+            scope_level=_provider_scope_level,
+            expected_scope_epoch=_expected_scope_epoch,
+            provider_is_root_scope=_provider_is_root_scope,
+            current_graph_revision=current_graph_revision,
+            compiled_graph_revision=_compiled_graph_revision,
+        )
+        try:
+            if current_graph_revision == _compiled_graph_revision:
+                return _fast_call()
+            return _resolve_stale_live_provider_sync(
+                resolver=_resolver,
+                runtime=_runtime,
+                container=_container,
+                current_graph_revision=current_graph_revision,
+                dependency=_dependency,
+                expected_scope_epoch=_expected_scope_epoch,
+            )
+        finally:
+            _resolver_end_live_provider_call(
+                resolver=_resolver,
+                started=provider_call_started,
+            )
+
+    return _sync_handle
+
+
+def _resolve_stale_live_provider_sync(
+    *,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    container: Any,
+    current_graph_revision: int,
+    dependency: Any,
+    expected_scope_epoch: int,
+) -> Any:
+    target_resolver = _stale_live_provider_target_resolver(
+        resolver=resolver,
+        runtime=runtime,
+        container=container,
+        current_graph_revision=current_graph_revision,
+        expected_scope_epoch=expected_scope_epoch,
+    )
+    target_provider_call_started = _resolver_begin_live_provider_call(
+        resolver=target_resolver,
+        scope_level=_resolver_live_provider_scope_level(
+            resolver=target_resolver,
+            runtime=getattr(type(target_resolver), "_runtime", None),
+        ),
+        expected_scope_epoch=_resolver_live_provider_epoch(resolver=target_resolver),
+    )
+    try:
+        return target_resolver.resolve(dependency)
+    finally:
+        _resolver_end_live_provider_call(
+            resolver=target_resolver,
+            started=target_provider_call_started,
+        )
+
+
+async def _resolve_stale_live_provider_async(
+    *,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    container: Any,
+    current_graph_revision: int,
+    dependency: Any,
+    expected_scope_epoch: int,
+) -> Any:
+    target_resolver = _stale_live_provider_target_resolver(
+        resolver=resolver,
+        runtime=runtime,
+        container=container,
+        current_graph_revision=current_graph_revision,
+        expected_scope_epoch=expected_scope_epoch,
+    )
+    target_provider_call_started = _resolver_begin_live_provider_call(
+        resolver=target_resolver,
+        scope_level=_resolver_live_provider_scope_level(
+            resolver=target_resolver,
+            runtime=getattr(type(target_resolver), "_runtime", None),
+        ),
+        expected_scope_epoch=_resolver_live_provider_epoch(resolver=target_resolver),
+    )
+    try:
+        return await target_resolver.aresolve(dependency)
+    finally:
+        _resolver_end_live_provider_call(
+            resolver=target_resolver,
+            started=target_provider_call_started,
+        )
+
+
+def _stale_live_provider_target_resolver(
+    *,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    container: Any,
+    current_graph_revision: int,
+    expected_scope_epoch: int,
+) -> Any:
+    class_plan = getattr(type(resolver), "_class_plan", None)
+    scope_level = getattr(class_plan, "scope_level", getattr(runtime, "root_scope_level", None))
+    if scope_level == runtime.root_scope_level:
+        return _live_provider_rebound_root_resolver(
+            resolver=resolver,
+            container=container,
+            graph_revision=current_graph_revision,
+            scope_level=runtime.root_scope_level,
+            expected_scope_epoch=expected_scope_epoch,
+        )
+    scope_level = cast("int", scope_level)
+
+    return _live_provider_rebound_scoped_resolver(
+        resolver=resolver,
+        runtime=runtime,
+        container=container,
+        graph_revision=current_graph_revision,
+        scope_level=scope_level,
+        expected_scope_epoch=expected_scope_epoch,
+    )
+
+
+def _live_provider_rebound_root_resolver(
+    *,
+    resolver: Any,
+    container: Any,
+    graph_revision: int,
+    scope_level: int,
+    expected_scope_epoch: int,
+) -> Any:
+    cache_key = (graph_revision, scope_level)
+    _resolver_ensure_live_provider_state(resolver)
+    cache = resolver._live_provider_scope_cache
+
+    with resolver._live_provider_lock:
+        _resolver_require_live_provider_scope_locked(
+            resolver=resolver,
+            scope_level=scope_level,
+            expected_scope_epoch=expected_scope_epoch,
+            allow_closing=True,
+        )
+
+        cached_resolver = cache.get(cache_key)
+        if cached_resolver is not None:
+            return cached_resolver
+
+        rebound_resolver = _latest_container_base_resolver(container=container)
+        cache[cache_key] = rebound_resolver
+        owned_scope_resolvers = resolver._owned_scope_resolvers
+        resolver._owned_scope_resolvers = (*owned_scope_resolvers, rebound_resolver)
+        return rebound_resolver
+
+
+def _live_provider_rebound_scoped_resolver(
+    *,
+    resolver: Any,
+    runtime: _ResolverRuntime,
+    container: Any,
+    graph_revision: int,
+    scope_level: int,
+    expected_scope_epoch: int,
+) -> Any:
+    cache_key = (graph_revision, scope_level)
+    _resolver_ensure_live_provider_state(resolver)
+    cache = resolver._live_provider_scope_cache
+
+    with resolver._live_provider_lock:
+        _resolver_require_live_provider_scope_locked(
+            resolver=resolver,
+            scope_level=scope_level,
+            expected_scope_epoch=expected_scope_epoch,
+            allow_closing=True,
+        )
+
+        cached_resolver = cache.get(cache_key)
+        if cached_resolver is not None:
+            return cached_resolver
+
+        scope_obj = runtime.scope_obj_by_level.get(scope_level, scope_level)
+        latest_root_resolver = _latest_container_base_resolver(container=container)
+        rebound_resolver = latest_root_resolver.enter_scope(scope_obj)
+        cache[cache_key] = rebound_resolver
+        owned_scope_resolvers = resolver._owned_scope_resolvers
+        resolver._owned_scope_resolvers = (
+            *owned_scope_resolvers,
+            latest_root_resolver,
+            rebound_resolver,
+        )
+        return rebound_resolver
+
+
+def _latest_container_base_resolver(*, container: Any) -> Any:
+    resolver = container.compile()
+    return getattr(resolver, "_resolver", resolver)
+
+
+def _resolver_live_provider_epoch(*, resolver: Any) -> int:
+    return cast("int", getattr(resolver, "_live_provider_epoch", 0))
+
+
+def _resolver_live_provider_scope_level(
+    *,
+    resolver: Any,
+    runtime: _ResolverRuntime | None,
+) -> int | None:
+    if runtime is None and getattr(resolver, "_base_resolver", None) is not None:
+        scope_level = getattr(resolver, "_scope_level", None)
+        if scope_level is not None:
+            return cast("int", scope_level)
+
+    if runtime is None:
+        return None
+    class_plan = getattr(type(resolver), "_class_plan", None)
+    root_scope_level = getattr(runtime, "root_scope_level", None)
+    if root_scope_level is None:
+        return None
+    scope_level = getattr(class_plan, "scope_level", root_scope_level)
+    return cast("int", scope_level)
+
+
+def _resolver_require_live_provider_scope_fast(
+    *,
+    resolver: Any,
+    scope_level: int | None,
+    expected_scope_epoch: int,
+) -> None:
+    if scope_level is None:
+        return
+
+    if (
+        not getattr(resolver, "_active", False)
+        or getattr(resolver, "_live_provider_closing", False)
+        or _resolver_live_provider_epoch(resolver=resolver) != expected_scope_epoch
+    ):
+        _raise_closed_live_provider_scope(scope_level=scope_level)
+
+
+def _live_provider_requires_same_revision_guard(
+    *,
+    runtime: _ResolverRuntime | None,
+    provider_slot: int | None,
+    dependency: Any,
+) -> bool:
+    if runtime is None:
+        return True
+    if provider_slot is None:
+        provider_slot = getattr(runtime, "dep_slot_by_key", {}).get(dependency)
+    if provider_slot is None:
+        return True
+    workflow = runtime.workflows_by_slot.get(provider_slot)
+    return workflow is None or workflow.needs_cleanup
+
+
+def _resolver_begin_live_provider_call(
+    *,
+    resolver: Any,
+    scope_level: int | None,
+    expected_scope_epoch: int,
+) -> bool:
+    if scope_level is None:
+        return False
+
+    _resolver_ensure_live_provider_state(resolver)
+    live_provider_lock = resolver._live_provider_lock
+    with live_provider_lock:
+        _resolver_require_live_provider_scope_locked(
+            resolver=resolver,
+            scope_level=scope_level,
+            expected_scope_epoch=expected_scope_epoch,
+        )
+        resolver._live_provider_inflight += 1
+        return True
+
+
+def _resolver_begin_guarded_live_provider_call(
+    *,
+    resolver: Any,
+    scope_level: int | None,
+    expected_scope_epoch: int,
+    provider_is_root_scope: bool,
+    current_graph_revision: int,
+    compiled_graph_revision: int,
+) -> bool:
+    if (
+        provider_is_root_scope
+        and current_graph_revision != compiled_graph_revision
+        and _resolver_in_live_provider_cleanup_context(resolver=resolver)
+    ):
+        return False
+    return _resolver_begin_live_provider_call(
+        resolver=resolver,
+        scope_level=scope_level,
+        expected_scope_epoch=expected_scope_epoch,
+    )
+
+
+def _resolver_end_live_provider_call(*, resolver: Any, started: bool) -> None:
+    if not started:
+        return
+
+    live_provider_condition = getattr(resolver, "_live_provider_condition", None)
+    if live_provider_condition is None:
+        return
+    with live_provider_condition:
+        resolver._live_provider_inflight -= 1
+        live_provider_condition.notify_all()
+
+
+def _resolver_require_live_provider_scope_locked(
+    *,
+    resolver: Any,
+    scope_level: int,
+    expected_scope_epoch: int,
+    allow_closing: bool = False,
+) -> None:
+    active_resolver = getattr(resolver, "_base_resolver", resolver)
+    default_active = active_resolver is not resolver
+    if (
+        not getattr(active_resolver, "_active", default_active)
+        or (getattr(resolver, "_live_provider_closing", False) and not allow_closing)
+        or _resolver_live_provider_epoch(resolver=resolver) != expected_scope_epoch
+    ):
+        _raise_closed_live_provider_scope(scope_level=scope_level)
+
+
+def _raise_closed_live_provider_scope(*, scope_level: int) -> NoReturn:
+    msg = (
+        f"Provider handle created in scope level {scope_level} cannot resolve against "
+        "a newer container graph after that scope has closed or started closing."
+    )
+    raise DIWireScopeMismatchError(msg)
 
 
 def _resolve_dispatch_fallback_sync(self: Any, dependency: Any) -> Any:
@@ -2353,8 +3301,18 @@ def _resolve_dispatch_fallback_sync(self: Any, dependency: Any) -> Any:
         if is_provider_annotation(inner):
             provider_inner = strip_provider_annotation(inner)
             if is_async_provider_annotation(inner):
-                return lambda: self.aresolve(provider_inner)
-            return lambda: self.resolve(provider_inner)
+                return _live_provider_handle(
+                    resolver=self,
+                    dependency=provider_inner,
+                    provider_slot=None,
+                    is_async=True,
+                )
+            return _live_provider_handle(
+                resolver=self,
+                dependency=provider_inner,
+                provider_slot=None,
+                is_async=False,
+            )
 
         if not self._is_registered_dependency(inner):
             return None
@@ -2372,8 +3330,18 @@ def _resolve_dispatch_fallback_sync(self: Any, dependency: Any) -> Any:
     if is_provider_annotation(dependency):
         inner = strip_provider_annotation(dependency)
         if is_async_provider_annotation(dependency):
-            return lambda: self.aresolve(inner)
-        return lambda: self.resolve(inner)
+            return _live_provider_handle(
+                resolver=self,
+                dependency=inner,
+                provider_slot=None,
+                is_async=True,
+            )
+        return _live_provider_handle(
+            resolver=self,
+            dependency=inner,
+            provider_slot=None,
+            is_async=False,
+        )
 
     if is_all_annotation(dependency):
         runtime = type(self)._runtime
@@ -2405,8 +3373,18 @@ def _resolve_dispatch_fallback_async(self: Any, dependency: Any) -> Awaitable[An
             if is_provider_annotation(inner):
                 provider_inner = strip_provider_annotation(inner)
                 if is_async_provider_annotation(inner):
-                    return lambda: self.aresolve(provider_inner)
-                return lambda: self.resolve(provider_inner)
+                    return _live_provider_handle(
+                        resolver=self,
+                        dependency=provider_inner,
+                        provider_slot=None,
+                        is_async=True,
+                    )
+                return _live_provider_handle(
+                    resolver=self,
+                    dependency=provider_inner,
+                    provider_slot=None,
+                    is_async=False,
+                )
 
             if not self._is_registered_dependency(inner):
                 return None
@@ -2424,8 +3402,18 @@ def _resolve_dispatch_fallback_async(self: Any, dependency: Any) -> Awaitable[An
         if is_provider_annotation(dependency):
             inner = strip_provider_annotation(dependency)
             if is_async_provider_annotation(dependency):
-                return lambda: self.aresolve(inner)
-            return lambda: self.resolve(inner)
+                return _live_provider_handle(
+                    resolver=self,
+                    dependency=inner,
+                    provider_slot=None,
+                    is_async=True,
+                )
+            return _live_provider_handle(
+                resolver=self,
+                dependency=inner,
+                provider_slot=None,
+                is_async=False,
+            )
 
         if is_all_annotation(dependency):
             runtime = type(self)._runtime
@@ -3095,9 +4083,17 @@ def _resolve_dependency_value_sync(
             msg = "Missing provider inner slot for provider-handle dependency plan."
             raise ValueError(msg)
 
-        if dependency_plan.provider_is_async:
-            return lambda: getattr(resolver, f"aresolve_{provider_inner_slot}")()
-        return lambda: getattr(resolver, f"resolve_{provider_inner_slot}")()
+        provider_inner_dependency = _provider_inner_dependency_for_handle_plan(
+            runtime=runtime,
+            dependency_plan=dependency_plan,
+            provider_inner_slot=provider_inner_slot,
+        )
+        return _live_provider_handle(
+            resolver,
+            provider_inner_dependency,
+            provider_inner_slot,
+            dependency_plan.provider_is_async,
+        )
 
     if dependency_plan.kind == "all":
         if not dependency_plan.all_slots:
@@ -3146,9 +4142,17 @@ def _resolve_dependency_value_async(
                 msg = "Missing provider inner slot for provider-handle dependency plan."
                 raise ValueError(msg)
 
-            if dependency_plan.provider_is_async:
-                return lambda: getattr(resolver, f"aresolve_{provider_inner_slot}")()
-            return lambda: getattr(resolver, f"resolve_{provider_inner_slot}")()
+            provider_inner_dependency = _provider_inner_dependency_for_handle_plan(
+                runtime=runtime,
+                dependency_plan=dependency_plan,
+                provider_inner_slot=provider_inner_slot,
+            )
+            return _live_provider_handle(
+                resolver,
+                provider_inner_dependency,
+                provider_inner_slot,
+                dependency_plan.provider_is_async,
+            )
 
         if dependency_plan.kind == "all":
             if not dependency_plan.all_slots:
@@ -3225,6 +4229,15 @@ def _dependency_value_for_slot_async(
         return getattr(resolver, f"resolve_{dependency_slot}")()
 
     return _run()
+
+
+def _provider_inner_dependency_for_handle_plan(
+    *,
+    runtime: _ResolverRuntime,
+    dependency_plan: ProviderDependencyPlan,
+    provider_inner_slot: int,
+) -> Any:
+    return runtime.dep_type_by_slot.get(provider_inner_slot, dependency_plan.dependency.provides)
 
 
 def _argument_part_for_dependency(

--- a/src/diwire/_internal/resolvers/manager.py
+++ b/src/diwire/_internal/resolvers/manager.py
@@ -15,6 +15,9 @@ class ResolversManager:
         self,
         root_scope: BaseScope,
         registrations: ProvidersRegistrations,
+        *,
+        live_provider_container: object | None = None,
+        live_provider_graph_revision: int | None = None,
     ) -> ResolverProtocol:
         """Get the root resolver for the given registrations.
 
@@ -23,10 +26,14 @@ class ResolversManager:
         Args:
             root_scope: Root scope used to initialize the resolver.
             registrations: Provider registrations used to build resolver instances or generated code.
+            live_provider_container: Optional owning container for live provider handles.
+            live_provider_graph_revision: Optional graph revision captured at compilation time.
 
         """
         validate_resolver_assembly_managed_scopes(root_scope=root_scope)
         return self._assembly_compiler.build_root_resolver(
             root_scope=root_scope,
             registrations=registrations,
+            live_provider_container=live_provider_container,
+            live_provider_graph_revision=live_provider_graph_revision,
         )

--- a/src/diwire/_internal/resolvers/protocol.py
+++ b/src/diwire/_internal/resolvers/protocol.py
@@ -123,5 +123,7 @@ class BuildRootResolverFunctionProtocol(Protocol):
         registrations: ProvidersRegistrations,
         *,
         cleanup_enabled: bool = True,
+        live_provider_container: object | None = None,
+        live_provider_graph_revision: int | None = None,
     ) -> ResolverProtocol:
         """Get the root resolver for the given registrations."""

--- a/tests/integrations/pytest/test_pytest_integration_minimal.py
+++ b/tests/integrations/pytest/test_pytest_integration_minimal.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from diwire import Container, Injected, Lifetime
+from diwire import AsyncProvider, Container, Injected, Lifetime
 
 pytest_plugins = ["diwire.integrations.pytest_plugin"]
 
@@ -12,6 +12,10 @@ class _Service:
 
 
 class _FakeService(_Service):
+    pass
+
+
+class _UpdatedService(_Service):
     pass
 
 
@@ -44,6 +48,32 @@ async def test_async_test_functions_support_injected_parameters(
     service: Injected[_Service],
 ) -> None:
     assert isinstance(service, _FakeService)
+
+
+@pytest.mark.asyncio
+async def test_async_provider_injected_parameter_sees_container_mutation_before_first_call(
+    diwire_container: Container,
+    service_provider: Injected[AsyncProvider[_Service]],
+) -> None:
+    diwire_container.add_instance(_UpdatedService(), provides=_Service)
+
+    service = await service_provider()
+
+    assert isinstance(service, _UpdatedService)
+
+
+@pytest.mark.asyncio
+async def test_async_provider_injected_parameter_sees_mutation_after_first_call(
+    diwire_container: Container,
+    service_provider: Injected[AsyncProvider[_Service]],
+) -> None:
+    before = await service_provider()
+
+    diwire_container.add_instance(_UpdatedService(), provides=_Service)
+    after = await service_provider()
+
+    assert isinstance(before, _FakeService)
+    assert isinstance(after, _UpdatedService)
 
 
 def test_regular_fixture_resolution_still_works_without_injected_parameters(value: int) -> None:

--- a/tests/unit/internal/test_container_context.py
+++ b/tests/unit/internal/test_container_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
+from types import TracebackType
 from typing import Any, cast
 
 import pytest
@@ -16,6 +17,62 @@ from diwire.exceptions import (
 class _Service:
     def __init__(self, value: str) -> None:
         self.value = value
+
+
+class _FakeSyncResolver:
+    def __init__(self, *, close_error: str | None = None, exit_error: str | None = None) -> None:
+        self.close_error = close_error
+        self.exit_error = exit_error
+        self.close_called = False
+        self.exit_called = False
+
+    def close(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: Any = None,
+    ) -> None:
+        self.close_called = True
+        if self.close_error is not None:
+            raise RuntimeError(self.close_error)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.exit_called = True
+        if self.exit_error is not None:
+            raise RuntimeError(self.exit_error)
+
+
+class _FakeAsyncResolver:
+    def __init__(self, *, close_error: str | None = None, exit_error: str | None = None) -> None:
+        self.close_error = close_error
+        self.exit_error = exit_error
+        self.close_called = False
+        self.exit_called = False
+
+    async def aclose(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_value: BaseException | None = None,
+        traceback: Any = None,
+    ) -> None:
+        self.close_called = True
+        if self.close_error is not None:
+            raise RuntimeError(self.close_error)
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.exit_called = True
+        if self.exit_error is not None:
+            raise RuntimeError(self.exit_error)
 
 
 def test_top_level_resolver_context_export_is_available() -> None:
@@ -35,12 +92,271 @@ def test_removed_enter_scope_context_kwarg_raises_type_error() -> None:
         container.enter_scope(Scope.REQUEST, **kwargs)  # type: ignore[arg-type]
 
 
+def test_container_exit_closes_current_and_entered_root_resolvers() -> None:
+    container = Container()
+    entered_resolver = _FakeSyncResolver()
+    current_resolver = _FakeSyncResolver()
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    container.__exit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+    assert container._entered_root_resolver is None
+
+
+def test_container_exit_reports_entered_cleanup_error_after_current_cleanup() -> None:
+    container = Container()
+    entered_resolver = _FakeSyncResolver(exit_error="entered boom")
+    current_resolver = _FakeSyncResolver(close_error="current boom")
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="entered boom"):
+        container.__exit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+    assert container._entered_root_resolver is None
+
+
+def test_container_exit_reports_current_error_after_entered_cleanup_succeeds() -> None:
+    container = Container()
+    entered_resolver = _FakeSyncResolver()
+    current_resolver = _FakeSyncResolver(close_error="current boom")
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="current boom"):
+        container.__exit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+
+
+def test_container_exit_with_entered_resolver_and_no_current_resolver() -> None:
+    container = Container()
+    entered_resolver = _FakeSyncResolver()
+    container._entered_root_resolver = cast("Any", entered_resolver)
+
+    container.__exit__(None, None, None)
+
+    assert entered_resolver.exit_called is True
+
+
+def test_container_exit_reports_entered_cleanup_error() -> None:
+    container = Container()
+    entered_resolver = _FakeSyncResolver(exit_error="entered boom")
+    current_resolver = _FakeSyncResolver()
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="entered boom"):
+        container.__exit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+
+
+def test_container_exit_with_only_current_resolver_reports_cleanup_error() -> None:
+    container = Container()
+    current_resolver = _FakeSyncResolver(close_error="current boom")
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="current boom"):
+        container.__exit__(None, None, None)
+
+    assert current_resolver.close_called is True
+
+
+def test_container_exit_reports_stale_root_cleanup_error() -> None:
+    container = Container()
+    stale_resolver = _FakeSyncResolver(close_error="stale boom")
+    container._stale_root_resolvers.append(cast("Any", stale_resolver))
+
+    with pytest.raises(RuntimeError, match="stale boom"):
+        container.__exit__(None, None, None)
+
+    assert stale_resolver.close_called is True
+    assert container._stale_root_resolvers == []
+
+
+def test_container_exit_continues_after_stale_root_cleanup_error() -> None:
+    container = Container()
+    first_resolver = _FakeSyncResolver(close_error="stale boom")
+    second_resolver = _FakeSyncResolver()
+    container._stale_root_resolvers.extend(
+        [cast("Any", first_resolver), cast("Any", second_resolver)]
+    )
+
+    with pytest.raises(RuntimeError, match="stale boom"):
+        container.__exit__(None, None, None)
+
+    assert first_resolver.close_called is True
+    assert second_resolver.close_called is True
+    assert container._stale_root_resolvers == []
+
+
+def test_container_exit_preserves_entered_error_after_stale_root_cleanup_error() -> None:
+    container = Container()
+    entered_resolver = _FakeSyncResolver(exit_error="entered boom")
+    stale_resolver = _FakeSyncResolver(close_error="stale boom")
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._stale_root_resolvers.append(cast("Any", stale_resolver))
+
+    with pytest.raises(RuntimeError, match="entered boom"):
+        container.__exit__(None, None, None)
+
+    assert entered_resolver.exit_called is True
+    assert stale_resolver.close_called is True
+    assert container._stale_root_resolvers == []
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_closes_current_and_entered_root_resolvers() -> None:
+    container = Container()
+    entered_resolver = _FakeAsyncResolver()
+    current_resolver = _FakeAsyncResolver()
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    await container.__aexit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+    assert container._entered_root_resolver is None
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_reports_entered_cleanup_error_after_current_cleanup() -> None:
+    container = Container()
+    entered_resolver = _FakeAsyncResolver(exit_error="entered boom")
+    current_resolver = _FakeAsyncResolver(close_error="current boom")
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="entered boom"):
+        await container.__aexit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+    assert container._entered_root_resolver is None
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_reports_current_error_after_entered_cleanup_succeeds() -> None:
+    container = Container()
+    entered_resolver = _FakeAsyncResolver()
+    current_resolver = _FakeAsyncResolver(close_error="current boom")
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="current boom"):
+        await container.__aexit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_with_entered_resolver_and_no_current_resolver() -> None:
+    container = Container()
+    entered_resolver = _FakeAsyncResolver()
+    container._entered_root_resolver = cast("Any", entered_resolver)
+
+    await container.__aexit__(None, None, None)
+
+    assert entered_resolver.exit_called is True
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_reports_entered_cleanup_error() -> None:
+    container = Container()
+    entered_resolver = _FakeAsyncResolver(exit_error="entered boom")
+    current_resolver = _FakeAsyncResolver()
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="entered boom"):
+        await container.__aexit__(None, None, None)
+
+    assert current_resolver.close_called is True
+    assert entered_resolver.exit_called is True
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_with_only_current_resolver_reports_cleanup_error() -> None:
+    container = Container()
+    current_resolver = _FakeAsyncResolver(close_error="current boom")
+    container._root_resolver = cast("Any", current_resolver)
+
+    with pytest.raises(RuntimeError, match="current boom"):
+        await container.__aexit__(None, None, None)
+
+    assert current_resolver.close_called is True
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_reports_stale_root_cleanup_error() -> None:
+    container = Container()
+    stale_resolver = _FakeAsyncResolver(close_error="stale boom")
+    container._stale_root_resolvers.append(cast("Any", stale_resolver))
+
+    with pytest.raises(RuntimeError, match="stale boom"):
+        await container.__aexit__(None, None, None)
+
+    assert stale_resolver.close_called is True
+    assert container._stale_root_resolvers == []
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_continues_after_stale_root_cleanup_error() -> None:
+    container = Container()
+    first_resolver = _FakeAsyncResolver(close_error="stale boom")
+    second_resolver = _FakeAsyncResolver()
+    container._stale_root_resolvers.extend(
+        [cast("Any", first_resolver), cast("Any", second_resolver)]
+    )
+
+    with pytest.raises(RuntimeError, match="stale boom"):
+        await container.__aexit__(None, None, None)
+
+    assert first_resolver.close_called is True
+    assert second_resolver.close_called is True
+    assert container._stale_root_resolvers == []
+
+
+@pytest.mark.asyncio
+async def test_container_async_exit_preserves_entered_error_after_stale_cleanup_error() -> None:
+    container = Container()
+    entered_resolver = _FakeAsyncResolver(exit_error="entered boom")
+    stale_resolver = _FakeAsyncResolver(close_error="stale boom")
+    container._entered_root_resolver = cast("Any", entered_resolver)
+    container._stale_root_resolvers.append(cast("Any", stale_resolver))
+
+    with pytest.raises(RuntimeError, match="entered boom"):
+        await container.__aexit__(None, None, None)
+
+    assert entered_resolver.exit_called is True
+    assert stale_resolver.close_called is True
+    assert container._stale_root_resolvers == []
+
+
 def test_resolver_context_does_not_expose_resolver_stack_mutators() -> None:
     context = ResolverContext()
 
     assert not hasattr(context, "push_resolver")
     assert not hasattr(context, "pop_resolver")
     assert not hasattr(context, "wrap_resolver")
+
+
+def test_resolver_context_empty_pop_is_noop() -> None:
+    context = ResolverContext()
+
+    context._pop()
+
+    assert context._get_bound_resolver_or_none() is None
 
 
 def test_resolve_raises_when_no_bound_resolver_and_no_fallback_container() -> None:

--- a/tests/unit/internal/test_lazy_providers.py
+++ b/tests/unit/internal/test_lazy_providers.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import threading
+from collections.abc import AsyncGenerator, Generator
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar, cast
 
@@ -11,13 +15,16 @@ from diwire import (
     DependencyRegistrationPolicy,
     Injected,
     Lifetime,
+    Maybe,
     Provider,
     Scope,
     resolver_context,
 )
+from diwire._internal.resolvers.assembly import compiler as resolver_compiler
 from diwire.exceptions import (
     DIWireAsyncDependencyInSyncContextError,
     DIWireInvalidProviderSpecError,
+    DIWireScopeMismatchError,
 )
 
 
@@ -120,6 +127,32 @@ class _AutoregDependency:
 class _AutoregConsumer:
     def __init__(self, dep_provider: Provider[_AutoregDependency]) -> None:
         self.dep_provider = dep_provider
+
+
+@dataclass(slots=True)
+class _LiveService:
+    value: str
+
+
+class _LiveProviderConsumer:
+    def __init__(self, service_provider: Provider[_LiveService]) -> None:
+        self._service_provider = service_provider
+
+    def get(self) -> _LiveService:
+        return self._service_provider()
+
+
+class _LiveAsyncProviderConsumer:
+    def __init__(self, service_provider: AsyncProvider[_LiveService]) -> None:
+        self._service_provider = service_provider
+
+    async def get(self) -> _LiveService:
+        return await self._service_provider()
+
+
+@dataclass(slots=True)
+class _LiveResource:
+    value: str
 
 
 @pytest.mark.asyncio
@@ -259,6 +292,1690 @@ async def test_injected_wrapper_supports_provider_and_async_provider() -> None:
     assert isinstance(await async_handler(), _InjectedConsumerDependency)
 
 
+def test_sync_provider_resolved_before_override_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    provider = container.resolve(Provider[_LiveService])
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert provider().value == "new"
+
+
+def test_sync_provider_called_before_override_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    provider = container.resolve(Provider[_LiveService])
+    before = provider()
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+    after = provider()
+
+    assert before.value == "old"
+    assert after.value == "new"
+
+
+def test_provider_resolved_from_stale_compiled_resolver_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    resolver = container.compile()
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+    provider = resolver.resolve(Provider[_LiveService])
+
+    assert provider().value == "new"
+
+
+def test_constructor_injected_provider_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add(_LiveProviderConsumer)
+
+    consumer = container.resolve(_LiveProviderConsumer)
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert consumer.get().value == "new"
+
+
+@pytest.mark.asyncio
+async def test_async_provider_resolved_before_override_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    provider = await container.aresolve(AsyncProvider[_LiveService])
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert (await provider()).value == "new"
+
+
+@pytest.mark.asyncio
+async def test_async_provider_called_before_override_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    provider = await container.aresolve(AsyncProvider[_LiveService])
+    before = await provider()
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+    after = await provider()
+
+    assert before.value == "old"
+    assert after.value == "new"
+
+
+@pytest.mark.asyncio
+async def test_async_provider_resolved_from_stale_compiled_resolver_uses_latest_container_graph() -> (
+    None
+):
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    resolver = container.compile()
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+    provider = resolver.resolve(AsyncProvider[_LiveService])
+
+    assert (await provider()).value == "new"
+
+
+@pytest.mark.asyncio
+async def test_constructor_injected_async_provider_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add(_LiveAsyncProviderConsumer)
+
+    consumer = container.resolve(_LiveAsyncProviderConsumer)
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert (await consumer.get()).value == "new"
+
+
+@pytest.mark.asyncio
+async def test_compiled_resolver_async_provider_uses_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    resolver = container.compile()
+
+    provider = resolver.resolve(AsyncProvider[_LiveService])
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert (await provider()).value == "new"
+
+
+@pytest.mark.asyncio
+async def test_maybe_provider_handles_use_latest_container_graph() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    provider = container.resolve(Maybe[Provider[_LiveService]])
+    async_provider = await container.aresolve(Maybe[AsyncProvider[_LiveService]])
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert provider is not None
+    assert async_provider is not None
+    assert provider().value == "new"
+    assert (await async_provider()).value == "new"
+
+
+def test_injected_sync_provider_handle_uses_latest_container_graph_after_mutation() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    @resolver_context.inject
+    def _handler(provider: Injected[Provider[_LiveService]]) -> Provider[_LiveService]:
+        return provider
+
+    handler = cast("Any", _handler)
+    provider = handler()
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert provider().value == "new"
+
+
+@pytest.mark.asyncio
+async def test_injected_async_provider_handle_uses_latest_container_graph_after_mutation() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    @resolver_context.inject
+    async def _handler(
+        provider: Injected[AsyncProvider[_LiveService]],
+    ) -> AsyncProvider[_LiveService]:
+        return provider
+
+    handler = cast("Any", _handler)
+    provider = await handler()
+
+    container.add_instance(_LiveService("new"), provides=_LiveService)
+
+    assert (await provider()).value == "new"
+
+
+def test_stale_scoped_provider_rebinds_same_scope_and_preserves_scoped_cache() -> None:
+    container = Container()
+    build_count = 0
+
+    def _build_old() -> _LiveService:
+        return _LiveService("old")
+
+    def _build_new() -> _LiveService:
+        nonlocal build_count
+        build_count += 1
+        return _LiveService(f"new-{build_count}")
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveService])
+
+        container.add_factory(
+            _build_new,
+            provides=_LiveService,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        first = provider()
+        second = provider()
+
+    assert first.value == "new-1"
+    assert first is second
+
+
+def test_concurrent_stale_scoped_provider_calls_share_single_rebound_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    container = Container()
+    build_count = 0
+
+    def _build_old() -> _LiveService:
+        return _LiveService("old")
+
+    def _build_new() -> _LiveService:
+        nonlocal build_count
+        build_count += 1
+        return _LiveService(f"new-{build_count}")
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveService])
+
+        container.add_factory(
+            _build_new,
+            provides=_LiveService,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        workers = 8
+        start_barrier = threading.Barrier(workers + 1)
+        latest_call_count = 0
+        latest_call_count_lock = threading.Lock()
+        entered_latest_resolver = threading.Event()
+        release_latest_resolver = threading.Event()
+        original_latest_resolver = resolver_compiler._latest_container_base_resolver
+
+        def _blocking_latest_resolver(*, container: Any) -> Any:
+            nonlocal latest_call_count
+            with latest_call_count_lock:
+                latest_call_count += 1
+            entered_latest_resolver.set()
+            if not release_latest_resolver.wait(timeout=5):
+                msg = "Timed out waiting to release latest resolver lookup."
+                raise RuntimeError(msg)
+            return original_latest_resolver(container=container)
+
+        def _call_provider() -> _LiveService:
+            start_barrier.wait(timeout=5)
+            return provider()
+
+        monkeypatch.setattr(
+            resolver_compiler,
+            "_latest_container_base_resolver",
+            _blocking_latest_resolver,
+        )
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(_call_provider) for _ in range(workers)]
+            start_barrier.wait(timeout=5)
+            assert entered_latest_resolver.wait(timeout=5)
+            assert not release_latest_resolver.wait(timeout=0.05)
+            release_latest_resolver.set()
+            resolved = [future.result(timeout=5) for future in futures]
+
+    assert latest_call_count == 1
+    assert build_count == 1
+    assert len({id(service) for service in resolved}) == 1
+    assert resolved[0].value == "new-1"
+
+
+def test_stale_provider_from_initially_stateless_scope_rebinds_without_inactive_error() -> None:
+    container = Container()
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+
+    with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveService])
+
+        container.add_factory(
+            lambda: _LiveService("new"),
+            provides=_LiveService,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        assert provider().value == "new"
+
+
+def test_stale_scoped_provider_from_reused_pooled_scope_stays_closed() -> None:
+    container = Container()
+    container.add_factory(
+        lambda: _LiveService("old"),
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+    root_resolver = container.compile()
+
+    with root_resolver.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveService])
+
+    container.add_factory(
+        lambda: _LiveService("new"),
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with root_resolver.enter_scope(Scope.REQUEST):
+        pass
+
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        provider()
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_async_provider_from_reused_pooled_scope_stays_closed() -> None:
+    container = Container()
+
+    async def _build_old() -> _LiveService:
+        return _LiveService("old")
+
+    async def _build_new() -> _LiveService:
+        return _LiveService("new")
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+    root_resolver = container.compile()
+
+    async with root_resolver.enter_scope(Scope.REQUEST) as request_scope:
+        provider = await request_scope.aresolve(AsyncProvider[_LiveService])
+
+    container.add_factory(
+        _build_new,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    async with root_resolver.enter_scope(Scope.REQUEST):
+        pass
+
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        await provider()
+
+
+def test_stale_scoped_provider_cleanup_preserves_outer_resolver_context() -> None:
+    container = Container()
+
+    def _build_old() -> _LiveService:
+        return _LiveService("old")
+
+    def _build_new() -> _LiveService:
+        return _LiveService("new")
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container as root_resolver:
+        with root_resolver.enter_scope(Scope.REQUEST) as request_scope:
+            provider = request_scope.resolve(Provider[_LiveService])
+
+            container.add_factory(
+                _build_new,
+                provides=_LiveService,
+                scope=Scope.REQUEST,
+                lifetime=Lifetime.SCOPED,
+            )
+
+            assert provider().value == "new"
+
+        assert resolver_context._get_bound_resolver_or_none() is root_resolver
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_async_provider_rebinds_same_scope_and_preserves_scoped_cache() -> None:
+    container = Container()
+    build_count = 0
+
+    async def _build_old() -> _LiveService:
+        return _LiveService("old")
+
+    async def _build_new() -> _LiveService:
+        nonlocal build_count
+        build_count += 1
+        return _LiveService(f"new-{build_count}")
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    async with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = await request_scope.aresolve(AsyncProvider[_LiveService])
+
+        container.add_factory(
+            _build_new,
+            provides=_LiveService,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        first = await provider()
+        second = await provider()
+
+    assert first.value == "new-1"
+    assert first is second
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stale_scoped_async_provider_calls_share_single_rebound_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    container = Container()
+    build_count = 0
+    latest_call_count = 0
+    original_latest_resolver = resolver_compiler._latest_container_base_resolver
+
+    async def _build_old() -> _LiveService:
+        return _LiveService("old")
+
+    async def _build_new() -> _LiveService:
+        nonlocal build_count
+        build_count += 1
+        await asyncio.sleep(0)
+        return _LiveService(f"new-{build_count}")
+
+    def _counting_latest_resolver(*, container: Any) -> Any:
+        nonlocal latest_call_count
+        latest_call_count += 1
+        return original_latest_resolver(container=container)
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    async with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = await request_scope.aresolve(AsyncProvider[_LiveService])
+
+        container.add_factory(
+            _build_new,
+            provides=_LiveService,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        monkeypatch.setattr(
+            resolver_compiler,
+            "_latest_container_base_resolver",
+            _counting_latest_resolver,
+        )
+        resolved = await asyncio.gather(*(provider() for _ in range(8)))
+
+    assert latest_call_count == 1
+    assert build_count == 1
+    assert len({id(service) for service in resolved}) == 1
+    assert resolved[0].value == "new-1"
+
+
+def test_stale_scoped_provider_rebound_scope_cleans_up_with_original_scope() -> None:
+    container = Container()
+    events: list[str] = []
+
+    def _provide_old() -> Generator[_LiveResource, None, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit")
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_generator(
+        _provide_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveResource])
+
+        container.add_generator(
+            _provide_new,
+            provides=_LiveResource,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        assert provider().value == "new"
+        assert events == ["new-enter"]
+
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_stale_scoped_provider_owns_latest_root_when_resolving_root_dependency() -> None:
+    container = Container()
+    events: list[str] = []
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    root_resolver = container.compile()
+    with root_resolver.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveResource])
+
+        container.add_generator(_provide_new, provides=_LiveResource)
+
+        assert provider().value == "new"
+    root_resolver.close()
+
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_stale_root_provider_latest_graph_cleans_up_when_container_context_exits() -> None:
+    container = Container()
+    events: list[str] = []
+
+    def _provide_old() -> Generator[_LiveResource, None, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit")
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_generator(_provide_old, provides=_LiveResource)
+
+    with container as root_resolver:
+        provider = root_resolver.resolve(Provider[_LiveResource])
+
+        container.add_generator(_provide_new, provides=_LiveResource)
+
+        assert provider().value == "new"
+        assert events == ["new-enter"]
+
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_same_revision_root_provider_call_racing_close_is_cleaned_up() -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    provider_started = threading.Event()
+    release_provider = threading.Event()
+    provider_result: list[_LiveResource] = []
+
+    def _provide_resource() -> Generator[_LiveResource, None, None]:
+        provider_started.set()
+        if not release_provider.wait(timeout=5):
+            msg = "Timed out waiting to release provider."
+            raise RuntimeError(msg)
+        events.append("enter")
+        try:
+            yield _LiveResource("same")
+        finally:
+            events.append("exit")
+
+    container.add_generator(_provide_resource, provides=_LiveResource)
+    provider = container.resolve(Provider[_LiveResource])
+
+    provider_thread = threading.Thread(target=lambda: provider_result.append(provider()))
+    provider_thread.start()
+    assert provider_started.wait(timeout=5)
+
+    close_thread = threading.Thread(target=container.close)
+    close_thread.start()
+    close_thread.join(timeout=0.05)
+    assert close_thread.is_alive()
+
+    release_provider.set()
+    provider_thread.join(timeout=5)
+    close_thread.join(timeout=5)
+
+    assert not provider_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert [resource.value for resource in provider_result] == ["same"]
+    assert events == ["enter", "exit"]
+
+
+def test_stale_root_provider_call_racing_close_is_cleaned_up() -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    provider_started = threading.Event()
+    release_provider = threading.Event()
+    provider_result: list[_LiveResource] = []
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        provider_started.set()
+        if not release_provider.wait(timeout=5):
+            msg = "Timed out waiting to release provider."
+            raise RuntimeError(msg)
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    provider = container.resolve(Provider[_LiveResource])
+    container.add_generator(_provide_new, provides=_LiveResource)
+
+    provider_thread = threading.Thread(target=lambda: provider_result.append(provider()))
+    provider_thread.start()
+    assert provider_started.wait(timeout=5)
+
+    close_thread = threading.Thread(target=container.close)
+    close_thread.start()
+    close_thread.join(timeout=0.05)
+    assert close_thread.is_alive()
+
+    release_provider.set()
+    provider_thread.join(timeout=5)
+    close_thread.join(timeout=5)
+
+    assert not provider_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert [resource.value for resource in provider_result] == ["new"]
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_stale_root_provider_racing_direct_resolver_close_before_latest_compile_is_cleaned_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    latest_compile_started = threading.Event()
+    release_latest_compile = threading.Event()
+    provider_result: list[_LiveResource] = []
+    provider_errors: list[BaseException] = []
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    resolver = container.compile()
+    provider = resolver.resolve(Provider[_LiveResource])
+    container.add_generator(_provide_new, provides=_LiveResource)
+    original_latest_resolver = resolver_compiler._latest_container_base_resolver
+
+    def _blocked_latest_resolver(*, container: Container) -> Any:
+        latest_compile_started.set()
+        if not release_latest_compile.wait(timeout=5):
+            msg = "Timed out waiting to release latest resolver compilation."
+            raise RuntimeError(msg)
+        return original_latest_resolver(container=container)
+
+    monkeypatch.setattr(
+        resolver_compiler,
+        "_latest_container_base_resolver",
+        _blocked_latest_resolver,
+    )
+
+    def _call_provider() -> None:
+        try:
+            provider_result.append(provider())
+        except BaseException as error:
+            provider_errors.append(error)
+
+    provider_thread = threading.Thread(target=_call_provider)
+    provider_thread.start()
+    assert latest_compile_started.wait(timeout=5)
+
+    close_thread = threading.Thread(target=resolver.close)
+    close_thread.start()
+    close_thread.join(timeout=0.05)
+    assert close_thread.is_alive()
+
+    release_latest_compile.set()
+    provider_thread.join(timeout=5)
+    close_thread.join(timeout=5)
+
+    assert not provider_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert provider_errors == []
+    assert [resource.value for resource in provider_result] == ["new"]
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_stale_root_provider_racing_container_close_after_mutation_is_cleaned_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    latest_compile_started = threading.Event()
+    release_latest_compile = threading.Event()
+    provider_result: list[_LiveResource] = []
+    provider_errors: list[BaseException] = []
+    close_errors: list[BaseException] = []
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    provider = container.resolve(Provider[_LiveResource])
+    container.add_generator(_provide_new, provides=_LiveResource)
+    original_latest_resolver = resolver_compiler._latest_container_base_resolver
+
+    def _blocked_latest_resolver(*, container: Container) -> Any:
+        latest_compile_started.set()
+        if not release_latest_compile.wait(timeout=5):
+            msg = "Timed out waiting to release latest resolver compilation."
+            raise RuntimeError(msg)
+        return original_latest_resolver(container=container)
+
+    monkeypatch.setattr(
+        resolver_compiler,
+        "_latest_container_base_resolver",
+        _blocked_latest_resolver,
+    )
+
+    def _call_provider() -> None:
+        try:
+            provider_result.append(provider())
+        except BaseException as error:
+            provider_errors.append(error)
+
+    def _close_container() -> None:
+        try:
+            container.close()
+        except BaseException as error:
+            close_errors.append(error)
+
+    provider_thread = threading.Thread(target=_call_provider)
+    provider_thread.start()
+    assert latest_compile_started.wait(timeout=5)
+
+    close_thread = threading.Thread(target=_close_container)
+    close_thread.start()
+    close_thread.join(timeout=0.05)
+    assert close_thread.is_alive()
+
+    release_latest_compile.set()
+    provider_thread.join(timeout=5)
+    close_thread.join(timeout=5)
+
+    assert not provider_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert provider_errors == []
+    assert close_errors == []
+    assert [resource.value for resource in provider_result] == ["new"]
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_stale_root_provider_resolved_from_compiled_resolver_owns_latest_root_cleanup() -> None:
+    container = Container()
+    events: list[str] = []
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    resolver = container.compile()
+    provider = resolver.resolve(Provider[_LiveResource])
+
+    container.add_generator(_provide_new, provides=_LiveResource)
+
+    assert provider().value == "new"
+    resolver.close()
+
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_stale_root_provider_called_from_cleanup_closes_latest_graph() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: Provider[_LiveService] | None = None
+
+    def _provide_resource() -> Generator[_LiveResource, None, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            events.append(f"cleanup-provider-{provider().value}")
+            events.append("old-exit-end")
+
+    def _provide_new_service() -> Generator[_LiveService, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+
+    with container as root_resolver:
+        provider = root_resolver.resolve(Provider[_LiveService])
+        assert root_resolver.resolve(_LiveResource).value == "old"
+
+        container.add_generator(_provide_new_service, provides=_LiveService)
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-enter",
+        "cleanup-provider-new",
+        "old-exit-end",
+        "new-exit",
+    ]
+
+
+def test_stale_root_provider_called_from_direct_resolver_cleanup_closes_latest_graph() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: Provider[_LiveService] | None = None
+
+    def _provide_resource() -> Generator[_LiveResource, None, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            events.append(f"cleanup-provider-{provider().value}")
+            events.append("old-exit-end")
+
+    def _provide_new_service() -> Generator[_LiveService, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+    root_resolver = container.compile()
+    provider = root_resolver.resolve(Provider[_LiveService])
+    assert root_resolver.resolve(_LiveResource).value == "old"
+
+    container.add_generator(_provide_new_service, provides=_LiveService)
+    root_resolver.close()
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-enter",
+        "cleanup-provider-new",
+        "old-exit-end",
+        "new-exit",
+    ]
+
+
+def test_stale_root_provider_called_before_and_during_cleanup_closes_latest_graph() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: Provider[_LiveService] | None = None
+
+    def _provide_resource() -> Generator[_LiveResource, None, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            events.append(f"cleanup-provider-{provider().value}")
+            events.append("old-exit-end")
+
+    def _provide_new_service() -> Generator[_LiveService, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+
+    with container as root_resolver:
+        provider = root_resolver.resolve(Provider[_LiveService])
+        assert root_resolver.resolve(_LiveResource).value == "old"
+
+        container.add_generator(_provide_new_service, provides=_LiveService)
+
+        events.append(f"body-provider-{provider().value}")
+
+    assert events == [
+        "old-enter",
+        "new-enter",
+        "body-provider-new",
+        "old-exit-start",
+        "cleanup-provider-new",
+        "old-exit-end",
+        "new-exit",
+    ]
+
+
+def test_stale_scoped_provider_call_during_cleanup_raises_scope_mismatch() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: Provider[_LiveResource] | None = None
+
+    def _build_old() -> _LiveResource:
+        return _LiveResource("old")
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-cleanup")
+            assert provider is not None
+            with pytest.raises(DIWireScopeMismatchError, match="started closing"):
+                provider()
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveResource])
+
+        container.add_generator(
+            _provide_new,
+            provides=_LiveResource,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        assert provider().value == "new"
+
+    assert events == ["new-enter", "new-cleanup"]
+
+
+def test_same_revision_scoped_provider_call_racing_close_is_cleaned_up() -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    provider_started = threading.Event()
+    release_provider = threading.Event()
+    provider_result: list[_LiveResource] = []
+    provider_errors: list[BaseException] = []
+
+    def _provide_resource() -> Generator[_LiveResource, None, None]:
+        provider_started.set()
+        if not release_provider.wait(timeout=5):
+            msg = "Timed out waiting to release provider."
+            raise RuntimeError(msg)
+        events.append("enter")
+        try:
+            yield _LiveResource("same")
+        finally:
+            events.append("exit")
+
+    container.add_generator(
+        _provide_resource,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+    request_scope = container.enter_scope(Scope.REQUEST)
+    request_scope.__enter__()
+    provider = request_scope.resolve(Provider[_LiveResource])
+
+    def _call_provider() -> None:
+        try:
+            provider_result.append(provider())
+        except BaseException as error:
+            provider_errors.append(error)
+
+    provider_thread = threading.Thread(target=_call_provider)
+    provider_thread.start()
+    assert provider_started.wait(timeout=5)
+
+    close_thread = threading.Thread(target=lambda: request_scope.__exit__(None, None, None))
+    close_thread.start()
+    close_thread.join(timeout=0.05)
+    assert close_thread.is_alive()
+
+    release_provider.set()
+    provider_thread.join(timeout=5)
+    close_thread.join(timeout=5)
+
+    assert not provider_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert provider_errors == []
+    assert [resource.value for resource in provider_result] == ["same"]
+    assert events == ["enter", "exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_async_provider_rebound_scope_cleans_up_with_original_scope() -> None:
+    container = Container()
+    events: list[str] = []
+
+    async def _provide_old() -> AsyncGenerator[_LiveResource, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit")
+
+    async def _provide_new() -> AsyncGenerator[_LiveResource, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_generator(
+        _provide_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    async with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = await request_scope.aresolve(AsyncProvider[_LiveResource])
+
+        container.add_generator(
+            _provide_new,
+            provides=_LiveResource,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        assert (await provider()).value == "new"
+        assert events == ["new-enter"]
+
+    assert events == ["new-enter", "new-exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_async_provider_owns_latest_root_for_root_dependency() -> None:
+    container = Container()
+    events: list[str] = []
+
+    async def _provide_new() -> AsyncGenerator[_LiveResource, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    root_resolver = container.compile()
+    async with root_resolver.enter_scope(Scope.REQUEST) as request_scope:
+        provider = await request_scope.aresolve(AsyncProvider[_LiveResource])
+
+        container.add_generator(_provide_new, provides=_LiveResource)
+
+        assert (await provider()).value == "new"
+    await root_resolver.aclose()
+
+    assert events == ["new-enter", "new-exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_async_provider_call_during_cleanup_raises_scope_mismatch() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: AsyncProvider[_LiveResource] | None = None
+
+    async def _build_old() -> _LiveResource:
+        return _LiveResource("old")
+
+    async def _provide_new() -> AsyncGenerator[_LiveResource, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-cleanup")
+            assert provider is not None
+            with pytest.raises(DIWireScopeMismatchError, match="started closing"):
+                await provider()
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    async with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = await request_scope.aresolve(AsyncProvider[_LiveResource])
+
+        container.add_generator(
+            _provide_new,
+            provides=_LiveResource,
+            scope=Scope.REQUEST,
+            lifetime=Lifetime.SCOPED,
+        )
+
+        assert (await provider()).value == "new"
+
+    assert events == ["new-enter", "new-cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_same_revision_scoped_async_provider_call_racing_close_is_cleaned_up() -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    provider_started = asyncio.Event()
+    release_provider = asyncio.Event()
+
+    async def _provide_resource() -> AsyncGenerator[_LiveResource, None]:
+        provider_started.set()
+        await release_provider.wait()
+        events.append("enter")
+        try:
+            yield _LiveResource("same")
+        finally:
+            events.append("exit")
+
+    container.add_generator(
+        _provide_resource,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+    request_scope = container.enter_scope(Scope.REQUEST)
+    await request_scope.__aenter__()
+    provider = await request_scope.aresolve(AsyncProvider[_LiveResource])
+
+    provider_task = asyncio.create_task(provider())
+    await asyncio.wait_for(provider_started.wait(), timeout=5)
+
+    close_task = asyncio.create_task(request_scope.__aexit__(None, None, None))
+    await asyncio.sleep(0.01)
+    assert not close_task.done()
+
+    release_provider.set()
+    resolved = await asyncio.wait_for(provider_task, timeout=5)
+    await asyncio.wait_for(close_task, timeout=5)
+
+    assert resolved.value == "same"
+    assert events == ["enter", "exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_root_async_provider_latest_graph_cleans_up_when_container_exits() -> None:
+    container = Container()
+    events: list[str] = []
+
+    async def _provide_old() -> AsyncGenerator[_LiveResource, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit")
+
+    async def _provide_new() -> AsyncGenerator[_LiveResource, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_generator(_provide_old, provides=_LiveResource)
+
+    async with container as root_resolver:
+        provider = await root_resolver.aresolve(AsyncProvider[_LiveResource])
+
+        container.add_generator(_provide_new, provides=_LiveResource)
+
+        assert (await provider()).value == "new"
+        assert events == ["new-enter"]
+
+    assert events == ["new-enter", "new-exit"]
+
+
+@pytest.mark.asyncio
+async def test_same_revision_root_async_provider_call_racing_close_is_cleaned_up() -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    provider_started = asyncio.Event()
+    release_provider = asyncio.Event()
+
+    async def _provide_resource() -> AsyncGenerator[_LiveResource, None]:
+        provider_started.set()
+        await release_provider.wait()
+        events.append("enter")
+        try:
+            yield _LiveResource("same")
+        finally:
+            events.append("exit")
+
+    container.add_generator(_provide_resource, provides=_LiveResource)
+    provider = await container.aresolve(AsyncProvider[_LiveResource])
+
+    provider_task = asyncio.create_task(provider())
+    await asyncio.wait_for(provider_started.wait(), timeout=5)
+
+    close_task = asyncio.create_task(container.aclose())
+    await asyncio.sleep(0.01)
+    assert not close_task.done()
+
+    release_provider.set()
+    resolved = await asyncio.wait_for(provider_task, timeout=5)
+    await asyncio.wait_for(close_task, timeout=5)
+
+    assert resolved.value == "same"
+    assert events == ["enter", "exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_root_async_provider_call_racing_close_is_cleaned_up() -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    provider_started = asyncio.Event()
+    release_provider = asyncio.Event()
+
+    async def _provide_new() -> AsyncGenerator[_LiveResource, None]:
+        provider_started.set()
+        await release_provider.wait()
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    provider = await container.aresolve(AsyncProvider[_LiveResource])
+    container.add_generator(_provide_new, provides=_LiveResource)
+
+    provider_task = asyncio.create_task(provider())
+    await asyncio.wait_for(provider_started.wait(), timeout=5)
+
+    close_task = asyncio.create_task(container.aclose())
+    await asyncio.sleep(0.01)
+    assert not close_task.done()
+
+    release_provider.set()
+    resolved = await asyncio.wait_for(provider_task, timeout=5)
+    await asyncio.wait_for(close_task, timeout=5)
+
+    assert resolved.value == "new"
+    assert events == ["new-enter", "new-exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_root_async_provider_resolved_from_compiled_resolver_owns_latest_root_cleanup() -> (
+    None
+):
+    container = Container()
+    events: list[str] = []
+
+    async def _provide_new() -> AsyncGenerator[_LiveResource, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveResource("old"), provides=_LiveResource)
+    resolver = container.compile()
+    provider = await resolver.aresolve(AsyncProvider[_LiveResource])
+
+    container.add_generator(_provide_new, provides=_LiveResource)
+
+    assert (await provider()).value == "new"
+    await resolver.aclose()
+
+    assert events == ["new-enter", "new-exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_root_async_provider_called_from_cleanup_closes_latest_graph() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: AsyncProvider[_LiveService] | None = None
+
+    async def _provide_resource() -> AsyncGenerator[_LiveResource, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            events.append(f"cleanup-provider-{(await provider()).value}")
+            events.append("old-exit-end")
+
+    async def _provide_new_service() -> AsyncGenerator[_LiveService, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+
+    async with container as root_resolver:
+        provider = await root_resolver.aresolve(AsyncProvider[_LiveService])
+        assert (await root_resolver.aresolve(_LiveResource)).value == "old"
+
+        container.add_generator(_provide_new_service, provides=_LiveService)
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-enter",
+        "cleanup-provider-new",
+        "old-exit-end",
+        "new-exit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stale_root_async_provider_called_from_direct_resolver_cleanup_closes_latest() -> (
+    None
+):
+    container = Container()
+    events: list[str] = []
+    provider: AsyncProvider[_LiveService] | None = None
+
+    async def _provide_resource() -> AsyncGenerator[_LiveResource, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            events.append(f"cleanup-provider-{(await provider()).value}")
+            events.append("old-exit-end")
+
+    async def _provide_new_service() -> AsyncGenerator[_LiveService, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+    root_resolver = container.compile()
+    provider = await root_resolver.aresolve(AsyncProvider[_LiveService])
+    assert (await root_resolver.aresolve(_LiveResource)).value == "old"
+
+    container.add_generator(_provide_new_service, provides=_LiveService)
+    await root_resolver.aclose()
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-enter",
+        "cleanup-provider-new",
+        "old-exit-end",
+        "new-exit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stale_root_async_provider_called_before_and_during_cleanup_closes_latest_graph() -> (
+    None
+):
+    container = Container()
+    events: list[str] = []
+    provider: AsyncProvider[_LiveService] | None = None
+
+    async def _provide_resource() -> AsyncGenerator[_LiveResource, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            events.append(f"cleanup-provider-{(await provider()).value}")
+            events.append("old-exit-end")
+
+    async def _provide_new_service() -> AsyncGenerator[_LiveService, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+
+    async with container as root_resolver:
+        provider = await root_resolver.aresolve(AsyncProvider[_LiveService])
+        assert (await root_resolver.aresolve(_LiveResource)).value == "old"
+
+        container.add_generator(_provide_new_service, provides=_LiveService)
+
+        events.append(f"body-provider-{(await provider()).value}")
+
+    assert events == [
+        "old-enter",
+        "new-enter",
+        "body-provider-new",
+        "old-exit-start",
+        "cleanup-provider-new",
+        "old-exit-end",
+        "new-exit",
+    ]
+
+
+def test_stale_scoped_provider_marks_original_scope_inactive_when_rebound_cleanup_fails() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: Provider[_LiveResource] | None = None
+
+    def _build_old() -> _LiveResource:
+        return _LiveResource("old")
+
+    def _provide_new() -> Generator[_LiveResource, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+            msg = "cleanup failed"
+            raise RuntimeError(msg)
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        with container.enter_scope(Scope.REQUEST) as request_scope:
+            provider = request_scope.resolve(Provider[_LiveResource])
+
+            container.add_generator(
+                _provide_new,
+                provides=_LiveResource,
+                scope=Scope.REQUEST,
+                lifetime=Lifetime.SCOPED,
+            )
+
+            assert provider().value == "new"
+
+    assert provider is not None
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        provider()
+    assert events == ["new-enter", "new-exit"]
+
+
+def test_stale_scoped_provider_closes_older_rebound_after_newer_cleanup_fails() -> None:
+    container = Container()
+    events: list[str] = []
+
+    def _build_old() -> _LiveResource:
+        return _LiveResource("old")
+
+    def _provide_one() -> Generator[_LiveResource, None, None]:
+        events.append("one-enter")
+        try:
+            yield _LiveResource("one")
+        finally:
+            events.append("one-exit")
+
+    def _provide_two() -> Generator[_LiveResource, None, None]:
+        events.append("two-enter")
+        try:
+            yield _LiveResource("two")
+        finally:
+            events.append("two-exit")
+            msg = "cleanup failed"
+            raise RuntimeError(msg)
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        with container.enter_scope(Scope.REQUEST) as request_scope:
+            provider = request_scope.resolve(Provider[_LiveResource])
+
+            container.add_generator(
+                _provide_one,
+                provides=_LiveResource,
+                scope=Scope.REQUEST,
+                lifetime=Lifetime.SCOPED,
+            )
+            assert provider().value == "one"
+
+            container.add_generator(
+                _provide_two,
+                provides=_LiveResource,
+                scope=Scope.REQUEST,
+                lifetime=Lifetime.SCOPED,
+            )
+            assert provider().value == "two"
+
+    assert events == ["one-enter", "two-enter", "two-exit", "one-exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_async_provider_marks_scope_inactive_when_cleanup_fails() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: AsyncProvider[_LiveResource] | None = None
+
+    async def _build_old() -> _LiveResource:
+        return _LiveResource("old")
+
+    async def _provide_new() -> AsyncGenerator[_LiveResource, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveResource("new")
+        finally:
+            events.append("new-exit")
+            msg = "cleanup failed"
+            raise RuntimeError(msg)
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        async with container.enter_scope(Scope.REQUEST) as request_scope:
+            provider = await request_scope.aresolve(AsyncProvider[_LiveResource])
+
+            container.add_generator(
+                _provide_new,
+                provides=_LiveResource,
+                scope=Scope.REQUEST,
+                lifetime=Lifetime.SCOPED,
+            )
+
+            assert (await provider()).value == "new"
+
+    assert provider is not None
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        await provider()
+    assert events == ["new-enter", "new-exit"]
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_async_provider_closes_older_rebound_after_cleanup_fails() -> None:
+    container = Container()
+    events: list[str] = []
+
+    async def _build_old() -> _LiveResource:
+        return _LiveResource("old")
+
+    async def _provide_one() -> AsyncGenerator[_LiveResource, None]:
+        events.append("one-enter")
+        try:
+            yield _LiveResource("one")
+        finally:
+            events.append("one-exit")
+
+    async def _provide_two() -> AsyncGenerator[_LiveResource, None]:
+        events.append("two-enter")
+        try:
+            yield _LiveResource("two")
+        finally:
+            events.append("two-exit")
+            msg = "cleanup failed"
+            raise RuntimeError(msg)
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveResource,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        async with container.enter_scope(Scope.REQUEST) as request_scope:
+            provider = await request_scope.aresolve(AsyncProvider[_LiveResource])
+
+            container.add_generator(
+                _provide_one,
+                provides=_LiveResource,
+                scope=Scope.REQUEST,
+                lifetime=Lifetime.SCOPED,
+            )
+            assert (await provider()).value == "one"
+
+            container.add_generator(
+                _provide_two,
+                provides=_LiveResource,
+                scope=Scope.REQUEST,
+                lifetime=Lifetime.SCOPED,
+            )
+            assert (await provider()).value == "two"
+
+    assert events == ["one-enter", "two-enter", "two-exit", "one-exit"]
+
+
+def test_inactive_scoped_stale_provider_raises_scope_mismatch() -> None:
+    container = Container()
+    container.add_factory(
+        lambda: _LiveService("old"),
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_LiveService])
+
+    container.add_factory(
+        lambda: _LiveService("new"),
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        provider()
+
+
+@pytest.mark.asyncio
+async def test_inactive_scoped_stale_async_provider_raises_scope_mismatch() -> None:
+    container = Container()
+
+    async def _build_old() -> _LiveService:
+        return _LiveService("old")
+
+    async def _build_new() -> _LiveService:
+        return _LiveService("new")
+
+    container.add_factory(
+        _build_old,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    async with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = await request_scope.aresolve(AsyncProvider[_LiveService])
+
+    container.add_factory(
+        _build_new,
+        provides=_LiveService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        await provider()
+
+
 T = TypeVar("T")
 
 
@@ -268,6 +1985,11 @@ class _OpenProviderService(Generic[T]):
 
 @dataclass
 class _OpenProviderServiceImpl(_OpenProviderService[T]):
+    type_arg: type[T]
+
+
+@dataclass
+class _OpenProviderCleanupOwner(Generic[T]):
     type_arg: type[T]
 
 
@@ -285,6 +2007,483 @@ def test_provider_direct_resolve_supports_open_generic_dependencies() -> None:
 
     assert isinstance(resolved, _OpenProviderServiceImpl)
     assert resolved.type_arg is int
+
+
+def test_open_generic_provider_handle_uses_latest_container_graph_after_mutation() -> None:
+    container = Container()
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+
+    provider = container.resolve(Provider[_OpenProviderService[int]])
+
+    container.add_instance(
+        _OpenProviderServiceImpl(type_arg=str),
+        provides=_OpenProviderService[int],
+    )
+
+    resolved = provider()
+
+    assert isinstance(resolved, _OpenProviderServiceImpl)
+    assert resolved.type_arg is str
+
+
+def test_open_generic_stale_root_provider_resolved_from_compiled_resolver_owns_latest_root_cleanup() -> (
+    None
+):
+    container = Container()
+    events: list[str] = []
+
+    def _provide_new_open() -> Generator[_OpenProviderService[int], None, None]:
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    resolver = container.compile()
+    provider = resolver.resolve(Provider[_OpenProviderService[int]])
+
+    container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+
+    resolved = provider()
+    assert isinstance(resolved, _OpenProviderServiceImpl)
+    assert resolved.type_arg is str
+
+    resolver.close()
+
+    assert events == ["new-open-enter", "new-open-exit"]
+
+
+def test_open_generic_stale_root_provider_call_racing_close_is_cleaned_up() -> None:
+    container = Container(use_resolver_context=False)
+    events: list[str] = []
+    provider_started = threading.Event()
+    release_provider = threading.Event()
+    provider_result: list[_OpenProviderService[int]] = []
+    provider_errors: list[BaseException] = []
+
+    def _provide_new_open() -> Generator[_OpenProviderService[int], None, None]:
+        provider_started.set()
+        if not release_provider.wait(timeout=5):
+            msg = "Timed out waiting to release provider."
+            raise RuntimeError(msg)
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    provider = container.resolve(Provider[_OpenProviderService[int]])
+    container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+
+    def _call_provider() -> None:
+        try:
+            provider_result.append(provider())
+        except BaseException as error:
+            provider_errors.append(error)
+
+    provider_thread = threading.Thread(target=_call_provider)
+    provider_thread.start()
+    assert provider_started.wait(timeout=5)
+
+    close_thread = threading.Thread(target=container.close)
+    close_thread.start()
+    close_thread.join(timeout=0.05)
+    assert close_thread.is_alive()
+
+    release_provider.set()
+    provider_thread.join(timeout=5)
+    close_thread.join(timeout=5)
+
+    assert not provider_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert provider_errors == []
+    assert len(provider_result) == 1
+    resolved = provider_result[0]
+    assert isinstance(resolved, _OpenProviderServiceImpl)
+    assert resolved.type_arg is str
+    assert events == ["new-open-enter", "new-open-exit"]
+
+
+def test_open_generic_root_provider_called_from_cleanup_closes_latest_graph() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: Provider[_OpenProviderService[int]] | None = None
+
+    def _provide_resource() -> Generator[_LiveResource, None, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            resolved = provider()
+            assert isinstance(resolved, _OpenProviderServiceImpl)
+            events.append(f"cleanup-provider-{resolved.type_arg.__name__}")
+            events.append("old-exit-end")
+
+    def _provide_new_open() -> Generator[_OpenProviderService[int], None, None]:
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+
+    with container as root_resolver:
+        provider = root_resolver.resolve(Provider[_OpenProviderService[int]])
+        assert root_resolver.resolve(_LiveResource).value == "old"
+
+        container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-open-enter",
+        "cleanup-provider-str",
+        "old-exit-end",
+        "new-open-exit",
+    ]
+
+
+def test_open_generic_root_provider_called_from_direct_resolver_cleanup_closes_latest() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: Provider[_OpenProviderService[int]] | None = None
+
+    def _provide_resource() -> Generator[_LiveResource, None, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            resolved = provider()
+            assert isinstance(resolved, _OpenProviderServiceImpl)
+            events.append(f"cleanup-provider-{resolved.type_arg.__name__}")
+            events.append("old-exit-end")
+
+    def _provide_new_open() -> Generator[_OpenProviderService[int], None, None]:
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+    root_resolver = container.compile()
+    provider = root_resolver.resolve(Provider[_OpenProviderService[int]])
+    assert root_resolver.resolve(_LiveResource).value == "old"
+
+    container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+    root_resolver.close()
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-open-enter",
+        "cleanup-provider-str",
+        "old-exit-end",
+        "new-open-exit",
+    ]
+
+
+def test_open_generic_cleanup_callback_can_call_stale_provider_before_base_closes() -> None:
+    container = Container()
+    events: list[str] = []
+
+    def _provide_open_owner(
+        type_arg: type[T],
+        service_provider: Provider[_LiveService],
+    ) -> Generator[_OpenProviderCleanupOwner[T], None, None]:
+        events.append("open-enter")
+        try:
+            yield _OpenProviderCleanupOwner(type_arg=type_arg)
+        finally:
+            events.append("open-exit-start")
+            events.append(f"cleanup-provider-{service_provider().value}")
+            events.append("open-exit-end")
+
+    def _provide_new_service() -> Generator[_LiveService, None, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_open_owner, provides=_OpenProviderCleanupOwner)
+    root_resolver = container.compile()
+    owner = root_resolver.resolve(_OpenProviderCleanupOwner[int])
+    assert owner.type_arg is int
+
+    container.add_generator(_provide_new_service, provides=_LiveService)
+    root_resolver.close()
+
+    assert events == [
+        "open-enter",
+        "open-exit-start",
+        "new-enter",
+        "cleanup-provider-new",
+        "open-exit-end",
+        "new-exit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_open_generic_async_provider_handle_uses_latest_container_graph_after_mutation() -> (
+    None
+):
+    container = Container()
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+
+    provider = await container.aresolve(AsyncProvider[_OpenProviderService[int]])
+
+    container.add_instance(
+        _OpenProviderServiceImpl(type_arg=str),
+        provides=_OpenProviderService[int],
+    )
+
+    resolved = await provider()
+
+    assert isinstance(resolved, _OpenProviderServiceImpl)
+    assert resolved.type_arg is str
+
+
+@pytest.mark.asyncio
+async def test_open_generic_stale_root_async_provider_from_compiled_resolver_owns_cleanup() -> None:
+    container = Container()
+    events: list[str] = []
+
+    async def _provide_new_open() -> AsyncGenerator[_OpenProviderService[int], None]:
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    resolver = container.compile()
+    provider = await resolver.aresolve(AsyncProvider[_OpenProviderService[int]])
+
+    container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+
+    resolved = await provider()
+    assert isinstance(resolved, _OpenProviderServiceImpl)
+    assert resolved.type_arg is str
+
+    await resolver.aclose()
+
+    assert events == ["new-open-enter", "new-open-exit"]
+
+
+@pytest.mark.asyncio
+async def test_open_generic_root_async_provider_called_from_cleanup_closes_latest_graph() -> None:
+    container = Container()
+    events: list[str] = []
+    provider: AsyncProvider[_OpenProviderService[int]] | None = None
+
+    async def _provide_resource() -> AsyncGenerator[_LiveResource, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            resolved = await provider()
+            assert isinstance(resolved, _OpenProviderServiceImpl)
+            events.append(f"cleanup-provider-{resolved.type_arg.__name__}")
+            events.append("old-exit-end")
+
+    async def _provide_new_open() -> AsyncGenerator[_OpenProviderService[int], None]:
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+
+    async with container as root_resolver:
+        provider = await root_resolver.aresolve(AsyncProvider[_OpenProviderService[int]])
+        assert (await root_resolver.aresolve(_LiveResource)).value == "old"
+
+        container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-open-enter",
+        "cleanup-provider-str",
+        "old-exit-end",
+        "new-open-exit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_open_generic_root_async_provider_from_direct_resolver_cleanup_closes_latest() -> (
+    None
+):
+    container = Container()
+    events: list[str] = []
+    provider: AsyncProvider[_OpenProviderService[int]] | None = None
+
+    async def _provide_resource() -> AsyncGenerator[_LiveResource, None]:
+        events.append("old-enter")
+        try:
+            yield _LiveResource("old")
+        finally:
+            events.append("old-exit-start")
+            assert provider is not None
+            resolved = await provider()
+            assert isinstance(resolved, _OpenProviderServiceImpl)
+            events.append(f"cleanup-provider-{resolved.type_arg.__name__}")
+            events.append("old-exit-end")
+
+    async def _provide_new_open() -> AsyncGenerator[_OpenProviderService[int], None]:
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    container.add_generator(_provide_resource, provides=_LiveResource)
+    root_resolver = container.compile()
+    provider = await root_resolver.aresolve(AsyncProvider[_OpenProviderService[int]])
+    assert (await root_resolver.aresolve(_LiveResource)).value == "old"
+
+    container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+    await root_resolver.aclose()
+
+    assert events == [
+        "old-enter",
+        "old-exit-start",
+        "new-open-enter",
+        "cleanup-provider-str",
+        "old-exit-end",
+        "new-open-exit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_open_generic_async_cleanup_can_call_stale_provider_before_base_closes() -> None:
+    container = Container()
+    events: list[str] = []
+
+    async def _provide_open_owner(
+        type_arg: type[T],
+        service_provider: AsyncProvider[_LiveService],
+    ) -> AsyncGenerator[_OpenProviderCleanupOwner[T], None]:
+        events.append("open-enter")
+        try:
+            yield _OpenProviderCleanupOwner(type_arg=type_arg)
+        finally:
+            events.append("open-exit-start")
+            events.append(f"cleanup-provider-{(await service_provider()).value}")
+            events.append("open-exit-end")
+
+    async def _provide_new_service() -> AsyncGenerator[_LiveService, None]:
+        events.append("new-enter")
+        try:
+            yield _LiveService("new")
+        finally:
+            events.append("new-exit")
+
+    container.add_instance(_LiveService("old"), provides=_LiveService)
+    container.add_generator(_provide_open_owner, provides=_OpenProviderCleanupOwner)
+    root_resolver = container.compile()
+    owner = await root_resolver.aresolve(_OpenProviderCleanupOwner[int])
+    assert owner.type_arg is int
+
+    container.add_generator(_provide_new_service, provides=_LiveService)
+    await root_resolver.aclose()
+
+    assert events == [
+        "open-enter",
+        "open-exit-start",
+        "new-enter",
+        "cleanup-provider-new",
+        "open-exit-end",
+        "new-exit",
+    ]
+
+
+def test_inactive_scoped_open_generic_stale_provider_raises_scope_mismatch() -> None:
+    container = Container()
+    container.add_factory(
+        _build_open_provider_service,
+        provides=_OpenProviderService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+
+    with container.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_OpenProviderService[int]])
+
+    container.add_instance(
+        _OpenProviderServiceImpl(type_arg=str),
+        provides=_OpenProviderService[int],
+    )
+
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        provider()
+
+
+def test_open_generic_stale_provider_from_reused_pooled_scope_stays_closed() -> None:
+    container = Container()
+    container.add_factory(
+        _build_open_provider_service,
+        provides=_OpenProviderService,
+        scope=Scope.REQUEST,
+        lifetime=Lifetime.SCOPED,
+    )
+    root_resolver = container.compile()
+
+    with root_resolver.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_OpenProviderService[int]])
+
+    container.add_instance(
+        _OpenProviderServiceImpl(type_arg=str),
+        provides=_OpenProviderService[int],
+    )
+
+    with root_resolver.enter_scope(Scope.REQUEST):
+        pass
+
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        provider()
+
+
+def test_scoped_open_generic_provider_owns_latest_root_for_root_dependency() -> None:
+    container = Container()
+    events: list[str] = []
+
+    def _provide_new_open() -> Generator[_OpenProviderService[int], None, None]:
+        events.append("new-open-enter")
+        try:
+            yield _OpenProviderServiceImpl(type_arg=cast("type[int]", str))
+        finally:
+            events.append("new-open-exit")
+
+    container.add_factory(_build_open_provider_service, provides=_OpenProviderService)
+    root_resolver = container.compile()
+    with root_resolver.enter_scope(Scope.REQUEST) as request_scope:
+        provider = request_scope.resolve(Provider[_OpenProviderService[int]])
+
+        container.add_generator(_provide_new_open, provides=_OpenProviderService[int])
+
+        resolved = provider()
+        assert isinstance(resolved, _OpenProviderServiceImpl)
+        assert resolved.type_arg is str
+    root_resolver.close()
+
+    assert events == ["new-open-enter", "new-open-exit"]
 
 
 def test_autoregistration_unwraps_provider_dependency() -> None:

--- a/tests/unit/internal/test_open_generics_helpers.py
+++ b/tests/unit/internal/test_open_generics_helpers.py
@@ -595,6 +595,111 @@ def test_open_generic_resolver_cache_first_touch_preserves_concurrent_writes() -
         assert resolver.get_cached(dependency) == dependency
 
 
+def test_live_provider_scope_level_uses_runtime_root_and_class_plan() -> None:
+    class _RuntimeWithoutRoot:
+        root_scope_level = None
+
+    class _ResolverWithoutRoot:
+        _runtime = _RuntimeWithoutRoot()
+
+    class _RuntimeWithRoot:
+        root_scope_level = 1
+
+    class _ClassPlan:
+        scope_level = 2
+
+    class _ResolverWithPlan:
+        _runtime = _RuntimeWithRoot()
+        _class_plan = _ClassPlan()
+
+    class _ResolverWithRootOnly:
+        _runtime = _RuntimeWithRoot()
+
+    assert (
+        open_generics._resolver_live_provider_scope_level(resolver=_ResolverWithoutRoot()) is None
+    )
+    assert open_generics._resolver_live_provider_scope_level(resolver=_ResolverWithPlan()) == 2
+    assert open_generics._resolver_live_provider_scope_level(resolver=_ResolverWithRootOnly()) == 1
+
+
+def test_live_provider_call_accounting_for_latest_resolver() -> None:
+    class _Runtime:
+        root_scope_level = 1
+
+    class _Resolver:
+        _runtime = _Runtime()
+
+        def __init__(self) -> None:
+            self._active = True
+            self._live_provider_lock = threading.RLock()
+            self._live_provider_condition = threading.Condition(self._live_provider_lock)
+            self._live_provider_inflight = 0
+
+    resolver = _Resolver()
+
+    assert open_generics._resolver_begin_live_provider_call(resolver=resolver) is True
+    assert resolver._live_provider_inflight == 1
+
+    open_generics._resolver_end_live_provider_call(resolver=resolver, started=True)
+    open_generics._resolver_end_live_provider_call(resolver=resolver, started=False)
+
+    assert resolver._live_provider_inflight == 0
+
+
+def test_live_provider_call_accounting_without_lock_or_condition() -> None:
+    class _ResolverWithoutRuntime:
+        pass
+
+    class _Runtime:
+        root_scope_level = 1
+
+    class _ResolverWithoutLock:
+        _runtime = _Runtime()
+        _active = True
+
+    class _ResolverWithoutCondition:
+        _runtime = _Runtime()
+        _active = True
+
+        def __init__(self) -> None:
+            self._live_provider_lock = threading.RLock()
+
+    assert (
+        open_generics._resolver_begin_live_provider_call(resolver=_ResolverWithoutRuntime())
+        is False
+    )
+    assert (
+        open_generics._resolver_begin_live_provider_call(resolver=_ResolverWithoutLock()) is False
+    )
+    open_generics._resolver_end_live_provider_call(
+        resolver=_ResolverWithoutCondition(),
+        started=True,
+    )
+
+
+def test_live_provider_call_accounting_rejects_closed_latest_resolver() -> None:
+    class _Runtime:
+        root_scope_level = 1
+
+    class _Resolver:
+        _runtime = _Runtime()
+
+        def __init__(self) -> None:
+            self._active = True
+            self._live_provider_closing = False
+            self._live_provider_lock = threading.RLock()
+
+    inactive_resolver = _Resolver()
+    inactive_resolver._active = False
+    closing_resolver = _Resolver()
+    closing_resolver._live_provider_closing = True
+
+    with pytest.raises(DIWireScopeMismatchError):
+        open_generics._resolver_begin_live_provider_call(resolver=inactive_resolver)
+    with pytest.raises(DIWireScopeMismatchError):
+        open_generics._resolver_begin_live_provider_call(resolver=closing_resolver)
+
+
 def test_open_generic_resolver_materialization_callback_runs_once_under_concurrency() -> None:
     registry = open_generics.OpenGenericRegistry()
     registry.register(

--- a/tests/unit/internal/test_resolver_assembly_compiler_branches.py
+++ b/tests/unit/internal/test_resolver_assembly_compiler_branches.py
@@ -210,6 +210,7 @@ def _runtime(
         has_cleanup=True,
         dep_registered_keys=set(),
         all_slots_by_key={} if all_slots_by_key is None else all_slots_by_key,
+        dep_slot_by_key={workflow.provides: workflow.slot for workflow in workflows},
         dep_eq_slot_by_key={} if dep_eq_slot_by_key is None else dep_eq_slot_by_key,
         dep_type_by_slot={workflow.slot: workflow.provides for workflow in workflows}
         if dep_type_by_slot is None
@@ -2575,6 +2576,33 @@ def test_resolve_dependency_value_sync_async_provider_handle_branch() -> None:
     assert asyncio.run(cast("Any", handle)()) == 77
 
 
+def test_live_provider_handle_snapshot_dispatch_branches() -> None:
+    class _SnapshotResolver:
+        def resolve(self, dependency: object) -> tuple[str, object]:
+            return ("sync", dependency)
+
+        async def aresolve(self, dependency: object) -> tuple[str, object]:
+            return ("async", dependency)
+
+    resolver = _SnapshotResolver()
+
+    sync_handle = compiler_module._live_provider_handle(
+        resolver,
+        int,
+        None,
+        is_async=False,
+    )
+    async_handle = compiler_module._live_provider_handle(
+        resolver,
+        str,
+        None,
+        is_async=True,
+    )
+
+    assert sync_handle() == ("sync", int)
+    assert asyncio.run(cast("Any", async_handle)()) == ("async", str)
+
+
 def test_resolver_scope_level_branch() -> None:
     resolver_type = type("ScopedResolver", (), {"_class_plan": SimpleNamespace(scope_level=9)})
     assert compiler_module._resolver_scope_level(resolver_type()) == 9
@@ -3057,6 +3085,229 @@ def test_execute_fast_single_cleanup_sync_tuple_unknown_kind_falls_back_to_close
     assert cleanup.closed is True
     assert resolver._cleanup_callback_single is None
     assert resolver._active is False
+
+
+def test_execute_fast_single_cleanup_sync_non_tuple_cleanup_closes() -> None:
+    class _CloseTracker:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    cleanup = _CloseTracker()
+    resolver = SimpleNamespace(
+        _cleanup_callback_single=cleanup,
+        _active=True,
+    )
+
+    compiler_module._execute_fast_single_cleanup_sync(
+        self=resolver,
+        single_cleanup=resolver._cleanup_callback_single,
+    )
+
+    assert cleanup.closed is True
+    assert resolver._cleanup_callback_single is None
+    assert resolver._active is False
+
+
+def test_live_provider_state_helpers_cover_lock_and_cache_branches() -> None:
+    reset_resolver = SimpleNamespace(
+        _owned_scope_resolvers=("owned",),
+        _live_provider_scope_cache={1: "cached"},
+        _live_provider_lock=None,
+        _live_provider_closing=True,
+        _live_provider_epoch=7,
+    )
+    compiler_module._resolver_reset_live_provider_state(reset_resolver)
+
+    assert reset_resolver._owned_scope_resolvers == ()
+    assert reset_resolver._live_provider_scope_cache is None
+    assert reset_resolver._live_provider_lock is None
+    assert reset_resolver._live_provider_closing is False
+    assert reset_resolver._live_provider_epoch == 8
+
+    locked_resolver_without_cache = SimpleNamespace(
+        _owned_scope_resolvers=("owned",),
+        _live_provider_lock=threading.RLock(),
+    )
+    compiler_module._resolver_clear_live_provider_rebounds(locked_resolver_without_cache)
+    assert locked_resolver_without_cache._owned_scope_resolvers == ()
+
+    unlocked_resolver_with_cache = SimpleNamespace(
+        _owned_scope_resolvers=("owned",),
+        _live_provider_scope_cache={1: "cached"},
+    )
+    compiler_module._resolver_clear_live_provider_rebounds(unlocked_resolver_with_cache)
+    assert unlocked_resolver_with_cache._owned_scope_resolvers == ()
+    assert unlocked_resolver_with_cache._live_provider_scope_cache is None
+
+    resolver_with_cache_without_flags = SimpleNamespace(
+        _live_provider_scope_cache={},
+        _live_provider_lock=None,
+    )
+    compiler_module._resolver_ensure_live_provider_state(resolver_with_cache_without_flags)
+    assert resolver_with_cache_without_flags._live_provider_scope_cache == {}
+    assert resolver_with_cache_without_flags._live_provider_lock is not None
+    assert resolver_with_cache_without_flags._live_provider_inflight == 0
+    assert resolver_with_cache_without_flags._live_provider_closing is False
+
+    resolver_without_condition = SimpleNamespace(_live_provider_inflight=1)
+    compiler_module._resolver_end_live_provider_call(
+        resolver=resolver_without_condition,
+        started=True,
+    )
+    assert resolver_without_condition._live_provider_inflight == 1
+
+
+@pytest.mark.asyncio
+async def test_guarded_provider_handles_call_same_revision_fast_path_with_guard() -> None:
+    async def _async_value() -> str:
+        return "async"
+
+    container = SimpleNamespace(_graph_revision=1)
+    runtime = SimpleNamespace()
+    sync_resolver = SimpleNamespace(
+        _active=True,
+        _live_provider_epoch=0,
+        _live_provider_closing=False,
+        _owned_scope_resolvers=(),
+    )
+    async_resolver = SimpleNamespace(
+        _active=True,
+        _live_provider_epoch=0,
+        _live_provider_closing=False,
+        _owned_scope_resolvers=(),
+    )
+
+    sync_handle = compiler_module._guarded_sync_live_provider_handle(
+        container=container,
+        compiled_graph_revision=1,
+        dependency=int,
+        resolver=sync_resolver,
+        runtime=cast("Any", runtime),
+        expected_scope_epoch=0,
+        provider_scope_level=Scope.REQUEST.level,
+        provider_is_root_scope=False,
+        requires_same_revision_guard=True,
+        fast_call=lambda: "sync",
+    )
+    async_handle = compiler_module._guarded_async_live_provider_handle(
+        container=container,
+        compiled_graph_revision=1,
+        dependency=int,
+        resolver=async_resolver,
+        runtime=cast("Any", runtime),
+        expected_scope_epoch=0,
+        provider_scope_level=Scope.REQUEST.level,
+        provider_is_root_scope=False,
+        requires_same_revision_guard=True,
+        fast_call=_async_value,
+    )
+
+    assert sync_handle() == "sync"
+    assert await async_handle() == "async"
+    assert sync_resolver._live_provider_inflight == 0
+    assert async_resolver._live_provider_inflight == 0
+
+
+def test_live_provider_rebound_scoped_resolver_allows_close_after_provider_call_started() -> None:
+    resolver = SimpleNamespace(
+        _active=True,
+        _live_provider_closing=True,
+        _live_provider_scope_cache={},
+        _live_provider_lock=threading.RLock(),
+        _owned_scope_resolvers=(),
+    )
+    runtime = SimpleNamespace(scope_obj_by_level={Scope.REQUEST.level: Scope.REQUEST})
+
+    rebound_resolver = compiler_module._live_provider_rebound_scoped_resolver(
+        resolver=resolver,
+        runtime=cast("Any", runtime),
+        container=Container(),
+        graph_revision=1,
+        scope_level=Scope.REQUEST.level,
+        expected_scope_epoch=0,
+    )
+
+    assert resolver._live_provider_scope_cache[(1, Scope.REQUEST.level)] is rebound_resolver
+    assert resolver._owned_scope_resolvers[-1] is rebound_resolver
+    assert len(resolver._owned_scope_resolvers) == 2
+
+
+def test_live_provider_scope_check_without_lock_uses_epoch() -> None:
+    class _RequestScopedResolverForEpochTest:
+        _class_plan = SimpleNamespace(scope_level=Scope.REQUEST.level)
+        _active = True
+        _live_provider_closing = False
+        _live_provider_epoch = 2
+
+    resolver = _RequestScopedResolverForEpochTest()
+    runtime = SimpleNamespace(root_scope_level=Scope.APP.level)
+    scope_level = compiler_module._resolver_live_provider_scope_level(
+        resolver=resolver,
+        runtime=cast("Any", runtime),
+    )
+
+    assert scope_level == Scope.REQUEST.level
+
+    compiler_module._resolver_require_live_provider_scope_fast(
+        resolver=resolver,
+        scope_level=scope_level,
+        expected_scope_epoch=2,
+    )
+
+    with pytest.raises(DIWireScopeMismatchError, match="scope has closed"):
+        compiler_module._resolver_require_live_provider_scope_fast(
+            resolver=resolver,
+            scope_level=scope_level,
+            expected_scope_epoch=1,
+        )
+
+    compiler_module._resolver_require_live_provider_scope_fast(
+        resolver=resolver,
+        scope_level=None,
+        expected_scope_epoch=1,
+    )
+    assert (
+        compiler_module._resolver_begin_live_provider_call(
+            resolver=resolver,
+            scope_level=None,
+            expected_scope_epoch=1,
+        )
+        is False
+    )
+    assert (
+        compiler_module._resolver_begin_live_provider_call(
+            resolver=resolver,
+            scope_level=scope_level,
+            expected_scope_epoch=2,
+        )
+        is True
+    )
+    compiler_module._resolver_end_live_provider_call(resolver=resolver, started=True)
+
+    assert (
+        compiler_module._resolver_live_provider_scope_level(
+            resolver=SimpleNamespace(),
+            runtime=None,
+        )
+        is None
+    )
+    assert (
+        compiler_module._resolver_live_provider_scope_level(
+            resolver=SimpleNamespace(_base_resolver=object(), _scope_level=Scope.APP.level),
+            runtime=None,
+        )
+        == Scope.APP.level
+    )
+    assert (
+        compiler_module._resolver_live_provider_scope_level(
+            resolver=SimpleNamespace(_base_resolver=object()),
+            runtime=None,
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make Provider and AsyncProvider handles live across container registration updates
- preserve scoped/root cleanup ownership for stale generated and open-generic providers
- add pytest integration coverage and provider examples for live registration updates

## Verification
- make lint
- make test
- make test-e2e-fastapi (blocked locally: docker command not found)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an example demonstrating live registration updates, where existing providers reflect newer registrations.
  * Expanded pytest plugin examples with clearer guidance for async provider injection.
* **Bug Fixes**
  * Improved provider resolution to follow the latest container graph after mutations and overrides.
  * Refined shutdown cleanup ordering and first-error reporting during close.
* **Documentation**
  * Updated how-to guides and the examples README with the new live-registration and pytest plugin materials.
* **Tests**
  * Added async provider integration tests and extensive live-provider cleanup behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->