### PR TITLE
fix: make async context entry awaitable

### DIFF
--- a/src/diwire/_internal/container.py
+++ b/src/diwire/_internal/container.py
@@ -2757,8 +2757,7 @@ class Container:
                     async_callable = cast("Callable[..., Awaitable[Any]]", callable_obj)
                     return await async_callable(*bound_arguments.args, **bound_arguments.kwargs)
 
-                async_scoped_resolver = cast("Any", maybe_scoped)
-                async with async_scoped_resolver:
+                async with maybe_scoped:
                     bound_arguments = await self._resolve_async_injected_arguments(
                         resolver=maybe_scoped,
                         signature=signature,
@@ -3709,11 +3708,11 @@ class Container:
         finally:
             self._entered_root_resolver = None
 
-    def __aenter__(self) -> ResolverProtocol:
+    async def __aenter__(self) -> ResolverProtocol:
         """Asynchronously enter the resolver context."""
         resolver = self.compile()
         self._entered_root_resolver = resolver
-        return resolver.__aenter__()
+        return await resolver.__aenter__()
 
     async def __aexit__(
         self,

--- a/src/diwire/_internal/resolver_context.py
+++ b/src/diwire/_internal/resolver_context.py
@@ -129,7 +129,7 @@ class _ResolverBoundResolver:
             self._pop_resolver()
 
     async def __aenter__(self) -> Self:
-        await cast("Any", self._resolver).__aenter__()
+        await self._resolver.__aenter__()
         self._push_resolver(cast("ResolverProtocol", self))
         return self
 

--- a/src/diwire/_internal/resolvers/protocol.py
+++ b/src/diwire/_internal/resolvers/protocol.py
@@ -69,7 +69,7 @@ class ResolverProtocol(Protocol):
         Like context managers or generators.
         """
 
-    def __aenter__(self) -> Self:
+    async def __aenter__(self) -> Self:
         """Asynchronously enter the resolver context."""
 
     async def __aexit__(

--- a/tests/unit/internal/test_resolver_runtime_assembly.py
+++ b/tests/unit/internal/test_resolver_runtime_assembly.py
@@ -1,3 +1,4 @@
+# mypy: enable-error-code="misc"
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
Closes #241.

`ResolverProtocol.__aenter__` and `Container.__aenter__` now use `async def`, and `Container` awaits the delegated resolver entry.
The corrected contract also removes two `Any` casts from internal async paths.

Existing async context runtime tests now run with mypy's `misc` checks enabled, covering direct and scoped entry without a separate type-test fixture.
`make lint` and `make test` pass.
The local FastAPI E2E could not start because Docker is not installed.
